### PR TITLE
Raise the default precision from 64 to 128

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ This module offers two flavors of Arbitrary-precision types that conforms to [Fl
 
 [FloatingPoint]: https://developer.apple.com/documentation/swift/floatingpoint
 
-In addition to all arithmetic operations that [FloatingPoint] supports.  Most of the functions in `<math.h>` are offered as static functions.  As you see in the synopsis above, all arithmetic functions and operators that are lossy can take `precision:Int` as an optional argument.  When omitted the value of `BigRat.precision` or `BigFloat.precision` is used (default:64).
+In addition to all arithmetic operations that [FloatingPoint] supports.  Most of the functions in `<math.h>` are offered as static functions.  As you see in the synopsis above, all arithmetic functions and operators that are lossy can take `precision:Int` as an optional argument.  When omitted the value of `BigRat.precision` or `BigFloat.precision` is used (default:128).
 
 ```swift
-BigFloat.sqrt(2) // 1.41421356237309504876
-BigFloat.precision = 128
 BigFloat.sqrt(2) // 1.414213562373095048801688724209698078569
+BigFloat.precision = 256
+BigFloat.sqrt(2) // 1.414213562373095048801688724209698078569671875376948073176679737990732478462102
 ```
 
 `BigInt`, an arbitrary-precision interger type is internally used and re-exported so you don't have to `import BigInt` just for that.  `BigInt` is also extended with `.over()` method so instead of constructing `BigRat` directly, you can:

--- a/Sources/BigNum/BigFloat.swift
+++ b/Sources/BigNum/BigFloat.swift
@@ -10,7 +10,7 @@ public struct BigFloat: Equatable, Hashable, Codable {  // automatic conformance
     public typealias Stride             = BigFloat
     public var scale:Exponent           // stored property
     public var mantissa:Significand     // stored property
-    public static var precision = 64
+    public static var precision = 128
     public static var roundingRule = FloatingPointRoundingRule.toNearestOrAwayFromZero
     public static var expLimit     = Self(Int16.max)
     // basic init

--- a/Sources/BigNum/Rational.swift
+++ b/Sources/BigNum/Rational.swift
@@ -442,7 +442,7 @@ public struct BigRational : BigRationalType & Codable {
     public typealias FloatLiteralType = Double
     public typealias Element = BigInt
     public typealias IntType = BigInt
-    public static var precision    = 64
+    public static var precision    = 128
     public static var roundingRule = FloatingPointRoundingRule.toNearestOrAwayFromZero
     public static var ATAN1 = (precision:0, value:nan)
     public static var E     = (precision:0, value:nan)


### PR DESCRIPTION
## What

`BigFloat.precision` and `BigRational.precision` now default to `128` instead of `64`.

- [`Sources/BigNum/BigFloat.swift`](../blob/raise-default-precision/Sources/BigNum/BigFloat.swift) — `public static var precision = 128`
- [`Sources/BigNum/Rational.swift`](../blob/raise-default-precision/Sources/BigNum/Rational.swift) — `public static var precision = 128`
- `README.md` — the documented default, plus the example that shows how to change it

## Why

That static is the fallback for every lossy operation called without an explicit `precision:` argument — `sqrt`, `exp`, `log`, the trig and hyperbolic family, `erf`/`gamma`, and the arithmetic operators. At 64 bits the out-of-the-box answer carried only ~19 decimal digits, which is barely past `Double`'s 53-bit significand and leaves no headroom for the cancellation these algorithms go through internally. 128 bits gives ~39 digits by default, and anyone who wants the old behaviour still has both the per-call argument and the static.

## Notes for the reviewer

**The README example had to change.** It previously demonstrated the knob by raising 64 to 128, which is now a no-op. It goes 128 → 256 instead, and both outputs are copied from an actual run rather than retyped:

```swift
BigFloat.sqrt(2) // 1.414213562373095048801688724209698078569
BigFloat.precision = 256
BigFloat.sqrt(2) // 1.414213562373095048801688724209698078569671875376948073176679737990732478462102
```

**`squareRoot(precision:)` is deliberately untouched.** `RationalType.squareRoot(precision:)`, `formSquareRoot(precision:)` and `formSquareRoot()` in `Rational.swift` keep their `Int64.bitWidth` default. That looks like the same 64 but it is a different knob: it feeds `w = 2 * max(num.bitWidth, den.bitWidth, |px|)`, so it acts as a *floor* on the internal working width, and it sits on the `RationalType` protocol, which has no static `precision` to defer to. Happy to move those too if you would rather have one number to change.

**Cost.** Calls that omit `precision:` now do roughly 2–4× the work — `BigFloat.gamma(x)` goes from ~13 ms to ~25 ms in a release build. That is the expected price of the extra bits, not a regression.

## Testing

`swift test -c release` — 23 tests, 0 failures. Spot-checked that the new default actually propagates: `BigFloat.precision` and `BigRat.precision` both report 128, `BigFloat.exp(1)` returns 39 digits, and the no-argument `erf` / `erfc` / `gamma` / `logGamma` shims all deliver ≥128 correct bits against reference values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)