### PR TITLE
Fix the five bugs the Swift Testing port turned up

### DIFF
--- a/Sources/BigNum/BigFloat.swift
+++ b/Sources/BigNum/BigFloat.swift
@@ -197,10 +197,30 @@ extension BigFloat : ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral {
     }
     // we have truncate, we have round
     public mutating func round(_ rule:FloatingPointRoundingRule=roundingRule) {
-        let width = scale + (mantissa.bitWidth-1)
-        mantissa.truncate(width: width, round: rule)
-        mantissa >>= (mantissa.bitWidth-1) - width
-        scale = 0
+        // ±0, ±∞ and NaN are already whole -- and their `scale` is Int.min or
+        // Int.max, which would overflow the arithmetic below
+        if self.isZero || self.isInfinite || self.isNaN { return }
+        if 0 <= scale { return }    // mantissa << scale is an integer already
+        let shift = -scale
+        let minus = mantissa < 0
+        let a = Swift.abs(mantissa)
+        let i = a >> shift              // ⌊|self|⌋
+        let r = a - (i << shift)        // 0 <= r < 1, as a multiple of 2^scale
+        let half = Significand(1) << (shift - 1)
+        let up:Bool
+        switch rule {
+        case .toNearestOrAwayFromZero:  up = half <= r
+        case .toNearestOrEven:          up = half < r || half == r && i & 1 == 1
+        case .awayFromZero:             up = 0 < r
+        case .towardZero:               up = false
+        case .down:                     up = 0 < r &&  minus   // toward -∞
+        case .up:                       up = 0 < r && !minus   // toward +∞
+        @unknown default:               fatalError()
+        }
+        let n = up ? i + 1 : i
+        // keep the sign when we round to zero, the way -0.2 -> -0.0 does
+        self = n == 0 ? (minus ? Self.negativeZero : Self.zero)
+                      : Self(scale:0, mantissa: minus ? -n : n)
     }
     public func rounded(_ rule:FloatingPointRoundingRule=roundingRule)->BigFloat {
         var result = self

--- a/Sources/BigNum/GenericMath.swift
+++ b/Sources/BigNum/GenericMath.swift
@@ -4,16 +4,15 @@ extension BigFloatingPoint {
     public static func SQRT2(precision px:Int=Self.precision, debug db:Bool=false)->Self {
         let apx = Swift.abs(px)
         if apx <= SQRT2.precision { return SQRT2.value.truncated(width: apx) }
-        SQRT2.precision = apx
-        SQRT2.value = Self(2).squareRoot(precision: apx)
-        return SQRT2.value
+        let v = Self(2).squareRoot(precision: apx)
+        SQRT2 = (precision: apx, value: v)  // publish together, value first
+        return v
     }
     /// euler's constant
     public static func E(precision px:Int=Self.precision, debug db:Bool=false)->Self {
         let apx = Swift.abs(px)
         if apx <= E.precision { return E.value.truncated(width: apx) }
-        E.precision = apx
-        E.value = E.value is BigRat ? {
+        let v:Self = E.value is BigRat ? {
             let epsilon = getEpsilon(precision: px)
             var (e, d) = (Self(1), Self(1))
             for i in 1 ... apx {
@@ -24,14 +23,14 @@ extension BigFloatingPoint {
             }
             return e.truncated(width: apx)
         }() : Self(BigRat.E(precision: apx))
-        return E.value
+        E = (precision: apx, value: v)      // publish together, value first
+        return v
     }
     /// log(2)
     public static func LN2(precision px:Int=Self.precision, debug db:Bool = false)->Self {
         let apx = Swift.abs(px)
         if apx <= LN2.precision { return LN2.value.truncated(width: apx) }
-        LN2.precision = apx
-        LN2.value = LN2.value is BigRat ? {
+        let v:Self = LN2.value is BigRat ? {
             let epsilon = getEpsilon(precision: px)
             var (t, r) = (Self(1)/Self(3), Self(1)/Self(3))
             for i in 1...px.magnitude {
@@ -42,15 +41,16 @@ extension BigFloatingPoint {
             }
             return (2*r).truncated(width: apx)
         }() : Self(BigRat.LN2(precision: apx))
-        return LN2.value
+        LN2 = (precision: apx, value: v)    // publish together, value first
+        return v
     }
     /// log(10)
     public static func LN10(precision px:Int=Self.precision, debug db:Bool=false)->Self {
         let apx = Swift.abs(px)
         if apx <= LN10.precision { return LN10.value.truncated(width: apx) }
-        LN10.precision = apx
-        LN10.value = Self.log(10, precision:apx)
-        return LN10.value
+        let v = Self.log(10, precision:apx)
+        LN10 = (precision: apx, value: v)   // publish together, value first
+        return v
     }
     /// π/4 in precision `px`.  Bellard's Formula
     public static func ATAN1(precision px:Int=Self.precision, debug db:Bool=false)->Self {
@@ -59,8 +59,7 @@ extension BigFloatingPoint {
         }
         let apx = Swift.abs(px)
         if apx <= ATAN1.precision { return ATAN1.value.truncated(width: apx) }
-        ATAN1.precision = apx
-        ATAN1.value = ATAN1.value is BigRat ? {
+        let v:Self = ATAN1.value is BigRat ? {
             let epsilon = getEpsilon(precision: px)
             var p64 = Self(0)
             for i in 0..<Int(apx.magnitude) {
@@ -86,7 +85,8 @@ extension BigFloatingPoint {
             p64 /= Self(1<<8)
             return p64.truncated(width: apx)
         }() : Self(BigRat.ATAN1(precision: apx))
-        return ATAN1.value
+        ATAN1 = (precision: apx, value: v)  // publish together, value first
+        return v
     }
     /// π in precision `px`.  4*atan(1)
     public static func PI(precision px:Int=Self.precision, debug db:Bool=false)->Self {
@@ -218,7 +218,9 @@ extension BigFloatingPoint {
             d *= Self(i)
             let t = n.divided(by:d, precision:px)
             r += t
-            if t < epsilon { break }
+            // compare the *magnitude*: for x < 0 this series alternates, and a
+            // signed test bails out on the very first term
+            if t.magnitude < epsilon { break }
         }
         return  0 < px ? r : r.truncated(width:px)
     }

--- a/Sources/BigNum/Rational.swift
+++ b/Sources/BigNum/Rational.swift
@@ -48,9 +48,13 @@ extension BigRationalType {
     public mutating func truncate(width:Int, round:FloatingPointRoundingRule=Self.roundingRule) {
         if self.isNaN || self.isZero || self.isInfinite { return }
         if width == 0       { return }
-        // if the denominator is power of 2, do nothing
-        guard 1 < den >> den.trailingZeroBitCount else { return }
         let w = width < 0 ? -width : +width
+        // A power-of-two denominator is already exact, so there is nothing to
+        // gain -- but only skip the work when the fraction really does fit in
+        // `w` bits. Bailing out unconditionally left the memoized constants at
+        // their full width (π/4 to 1151 bits keeps a 1153-bit denominator),
+        // which then overflows asDouble().
+        if den >> den.trailingZeroBitCount == 1 && num.bitWidth - 1 <= w { return }
         let s = max(den.bitWidth - 1, w)    // -1 for sign bit
         let d = Element(1) << s
         var n = (num << (s+2)) / den    // 2 bits for rounding hint
@@ -280,7 +284,18 @@ extension RationalType {
         if self.isInfinite {
             return self.sign == .minus ? -Double.infinity : +Double.infinity
         }
-        let r = Double(BigInt(num)) / Double(BigInt(den))
+        var (n, d) = (BigInt(num), BigInt(den))
+        // Both sides can sit far above Double's range while their ratio is
+        // perfectly ordinary -- π/4 held to 1151 bits, say. Double(n)/Double(d)
+        // would be inf/inf, i.e. NaN, so shift them down together first: the
+        // quotient is unchanged and ~1000 bits of it survive, far more than the
+        // 53 a Double can keep.
+        let excess = Swift.max(n.bitWidth, d.bitWidth) - 1000
+        if 0 < excess {
+            let w = Swift.min(excess, Swift.min(n.bitWidth, d.bitWidth) - 1)
+            if 0 < w { (n, d) = (n >> w, d >> w) }
+        }
+        let r = Double(n) / Double(d)
         if r.isZero {       // we know it is not zero so try again with subnormal handling
             let w = Swift.min(den.trailingZeroBitCount, den.bitWidth - 1024)
             return Double(BigInt(num)) / Double(BigInt(den >> w)) / Double(BigInt(1) << w)

--- a/Tests/BigNumTests/BigNumTests.swift
+++ b/Tests/BigNumTests/BigNumTests.swift
@@ -50,16 +50,9 @@ import Testing
     @Test(arguments: roundingDoubles)
     func bigRatRound(_ d:D)   { runRound(forType:BigRat.self,   d) }
 
-    // FIXME: BigFloat.round() is broken and was never actually exercised --
-    // the old testBigFloatRound() called runArithmetic() by mistake. It
-    //   * traps on -0.0 and NaN: their `scale` is Int.min/Int.max, so
-    //     `scale + (mantissa.bitWidth-1)` overflows,
-    //   * ignores the rule and truncates toward zero (2.5.rounded(.up) == 2),
-    //   * leaves the mantissa denormalized, so even a correct value compares
-    //     unequal to the same number built by init().
-    // BigRat.round() gets all three right by returning early on
-    // isZero/isInfinite/isNaN and going through asMixed.
-    @Test(.disabled("BigFloat.round() traps on -0.0 and ignores the rounding rule"),
-          arguments: roundingDoubles)
+    // NOTE: this never actually ran before -- the old testBigFloatRound() called
+    // runArithmetic() by copy-paste, which is how BigFloat.round() came to trap
+    // on -0.0, ignore the rule and denormalize its mantissa unnoticed.
+    @Test(arguments: roundingDoubles)
     func bigFloatRound(_ d:D) { runRound(forType:BigFloat.self, d) }
 }

--- a/Tests/BigNumTests/GenericMathTests.swift
+++ b/Tests/BigNumTests/GenericMathTests.swift
@@ -5,13 +5,14 @@ import Foundation
 /// `GenericMath` against `Double`'s `<math.h>`, one edge-case argument per test.
 ///
 /// `.serialized` is load-bearing, not a style choice. `GenericMath` memoizes
-/// √2, e, log 2, log 10 and π/4 in plain `static var`s with no synchronization,
-/// and it publishes the new `.precision` *before* it stores the new `.value`.
-/// Nested calls raise the working precision as they go (`logGamma` recurses at
-/// `px + 32`, `erfc` asks for `getEpsilon(precision: px * 2)`), so the write
-/// path is reachable at any precision -- pre-computing the constants up front
-/// does not close the window. Run two of these concurrently, as Swift Testing
-/// does by default, and they hand each other a half-written NaN.
+/// √2, e, log 2, log 10 and π/4 in plain `static var`s. They now store the
+/// value and its precision in one assignment rather than publishing the
+/// precision first, so a reader can no longer pick up a NaN that a writer has
+/// not filled in yet -- but a tuple of `Int` and a BigInt-backed struct still
+/// is not written atomically, so two threads can tear one. Nested calls raise
+/// the working precision constantly (`logGamma` recurses at `px + 32`, `erfc`
+/// asks for `getEpsilon(precision: px * 2)`), so the write path stays live at
+/// every precision and pre-computing the constants would not close the window.
 /// BigNumTests and RationalTests never reach these caches, so they stay parallel.
 @Suite(.serialized) struct GenericMathTests {
     typealias D = Double
@@ -41,18 +42,11 @@ import Foundation
         // exponentials -- Double overflows well before BigNum does
         (rd, rq) = (D.exp(d), T.exp(q, precision:px))
         check("exp", rd, rq, unless: d == D.log(rq.asDouble) || lgfm < d.magnitude)
-        // KNOWN BUG: expMinusOne() sums an alternating series and breaks out on
-        // `t < epsilon` with a *signed* t, so for -log 2 < x < 0 it returns after
-        // the very first term -- expMinusOne(-0.5) == -0.5, not -0.3934693...
-        // (exp() has the same test but is safe: it reflects negatives first.)
-        // The old suite could not see this: its error term was
-        // `abs(qrd - rq) / rq`, and dividing by the *signed* result made every
-        // negative answer compare as within tolerance no matter how wrong.
+        // NOTE: negative arguments are the interesting ones here -- this series
+        // alternates, and it used to break out of the loop on a *signed* term
+        // comparison, returning after the very first one.
         (rd, rq) = (D.expMinusOne(d), T.expMinusOne(q, precision:px))
-        withKnownIssue("expMinusOne() aborts its series for negative x",
-                       isIntermittent: true) {  // exact for arguments near zero
-            check("expMinusOne", rd, rq, unless: d == D.log(onePlus:rq.asDouble))
-        }
+        check("expMinusOne", rd, rq, unless: d == D.log(onePlus:rq.asDouble))
         // logarithms
         (rd, rq) = (D.log(d), T.log(q, precision:px))
         check("log", rd, rq, unless: d == D.exp(rq.asDouble))
@@ -98,7 +92,9 @@ import Foundation
 
     // BigRat is left out on purpose: exact rationals blow up on the
     // transcendentals, and BigFloat exercises the same GenericMath code.
-    @Test(arguments: edgeDoubles.filter { $0.magnitude != .greatestFiniteMagnitude })
+    // The two extremes are the expensive ones -- sin/cos of an angle that large
+    // make normalizeAngle() reduce it against pi at 128 + 1023 bits.
+    @Test(arguments: edgeDoubles)
     func unaryBigFloat(_ d:D) { runUnary(forType:BigFloat.self, d) }
 
     // MARK: atan2 -- all nine sign/zero/infinity quadrant cases
@@ -180,23 +176,4 @@ import Foundation
     @Test func erfGammaExactBigRat()   { runErfGammaExact(forType:BigRat.self) }
     @Test func erfGammaExactBigFloat() { runErfGammaExact(forType:BigFloat.self) }
 
-    // MARK: the two extremes of the exponent range
-
-    /// KNOWN BUG -- this test has to come last, and `.serialized` above is what
-    /// guarantees it does. `sin`/`cos`/`tan` of an angle this large make
-    /// `normalizeAngle()` ask for π at `128 + 1023` bits, and that poisons the
-    /// shared constant cache for good:
-    ///
-    ///   * `RationalType.truncate(width:)` sizes the denominator with
-    ///     `max(den.bitWidth - 1, width)`, so truncating that π/4 back down to
-    ///     128 bits keeps its 1153-bit denominator;
-    ///   * `BigRat.asDouble` then divides two BigInts that are each far past
-    ///     `Double`'s range, so `inf/inf` comes back as NaN.
-    ///
-    /// From that point on every `BigRat.PI()` at <= 1151 bits reads the cached
-    /// value and returns NaN, which takes `atan2`, `erf`, `gamma` and friends
-    /// with it. The old suite never noticed because XCTest ran its tests in
-    /// alphabetical order, which put `testUnaryBigFloat` last by luck.
-    @Test(arguments: [-D.greatestFiniteMagnitude, +D.greatestFiniteMagnitude])
-    func unaryBigFloatAtTheExtremes(_ d:D) { runUnary(forType:BigFloat.self, d) }
 }


### PR DESCRIPTION
Follow-up to #12. All five bugs were live in the library, not the tests — each had gone unnoticed because the old suite either never ran the code or could not see a wrong answer when it did.

**Test suite: 5m13s → 54s, 23 tests / 129 cases, all passing.** (11m34s before the port.)

## 1. `BigFloat.round()` — rewritten

It computed `scale + (mantissa.bitWidth-1)`, which overflows for `-0.0` (`scale` is `Int.min`) and for NaN/∞ (`Int.max`), then fed that to `SignedInteger.truncate()` in a way that:

- ignored the rounding rule and truncated toward zero — `2.5.rounded(.up) == 2`
- left the mantissa denormalized, so even a correct value compared unequal to the same number from `init()`

Now returns early for the non-finite cases, applies each of the six rules to the fractional bits directly, and keeps the sign when rounding to zero (`-0.2` → `-0.0`).

Nothing had ever exercised this: `testBigFloatRound()` called `runArithmetic()` by copy-paste.

## 2. `expMinusOne()` — compare the magnitude

The series alternates for `x < 0`, so the signed `t < epsilon` test matched on the very first term and returned it verbatim: `expMinusOne(-0.5)` gave `-0.5` instead of `-0.3934693…`, wrong by 27%. `exp()` shares the test but is safe, having reflected negatives first.

## 3. `RationalType.truncate(width:)` — don't skip every power-of-two denominator

The guard bailed out for *any* power-of-two denominator. Since the memoized constants all have power-of-two denominators, they were **never actually truncated**: π/4 requested once at 1151 bits stayed 1151 bits forever, and every later computation dragged those full-width rationals along. Now it only skips when the fraction already fits the requested width.

This is the change that takes the suite from 5m13s to 54s.

## 4. `BigRat.asDouble` — scale both ends before dividing

Numerator and denominator can both exceed `Double`'s range while their ratio is perfectly ordinary (that π/4 again). `Double(num)/Double(den)` was then `inf/inf` — NaN, which fell through both the `isZero` and `isInfinite` fallbacks. Now shifts both down together first; ~1000 bits of the quotient survive, against the 53 a `Double` can hold.

## 5. Constant caches — publish value and precision together

`SQRT2`, `E`, `LN2`, `LN10` and `ATAN1` set `.precision` *before* storing `.value`. A reader arriving mid-write saw the new precision alongside a value still holding NaN, and returned that NaN for every request at or below it. Now a single tuple assignment, which also fixes the re-entrant case where `BigFloat`'s constant delegates to `BigRat`'s.

## Test changes

- `bigFloatRound` and the full 21-argument `unaryBigFloat` are enabled again
- the `expMinusOne` `withKnownIssue` is gone
- the huge-angle case is back in the main sweep now that it no longer poisons the π cache

`GenericMathTests` stays `.serialized`: the caches are written in one assignment now, but a tuple of `Int` and a BigInt-backed struct still isn't written *atomically*, so concurrent writers can tear one. Making them genuinely thread-safe needs a lock (recursive, since `BigFloat`'s constants call `BigRat`'s) — happy to add that if you want the suite parallel.

## Reviewer notes

- The accuracy checks are unchanged and still strict: `erfGammaExactBigRat` verifies 40 decimal digits at 256-bit precision, so the speedup is not coming from weaker assertions.
- `-2.5.rounded(.toNearestOrEven)` → `-2`, `0.5.rounded(.toNearestOrEven)` → `0`, `-0.2.rounded(.down)` → `-1`: all six rules now match `Double` across the tie cases for both `BigRat` and `BigFloat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)