### PR TITLE
Add power(_:mod:), modular exponentiation after Python's pow()

### DIFF
--- a/BigInt.md
+++ b/BigInt.md
@@ -167,6 +167,69 @@ BigInt(-12).greatestCommonDivisor(with: 18)      // 6   -- always non-negative
 directly — it is on `BigRat`'s hot path, since every rational reduces on
 construction.
 
+## `power(_:mod:)`: modular exponentiation
+
+`power(_:mod:)` is Python's three-argument `pow()`. It is not `power(_:) % m`
+— the intermediates are reduced as they are formed, which is what makes it
+usable at all:
+
+```swift
+BigInt(2).power(10, mod: 1000)                    // 24
+BigInt(123456789).power(12345, mod: 1000000007)   // 614455772
+BigUInt(2).power(64, mod: (BigUInt(1) << 64) + 13)   // 18446744073709551616
+```
+
+Nothing ever grows past twice the modulus's width, so the cost is one squaring
+per exponent bit rather than a result with `exponent * self.bitWidth` bits of it.
+`BigInt(2).power(1000000, mod: 7)` is instant; `BigInt(2).power(1000000) % 7`
+builds a million-bit number first.
+
+Three conventions, all Python's:
+
+**The result takes the sign of the modulus.** That is a floored remainder, unlike
+the truncated one `%` gives:
+
+```swift
+BigInt(-2).power(3, mod: 5)     //  2      -- floored, in 0..<5
+BigInt(-2).power(3) % 5         // -3      -- what `%` would say
+BigInt(2).power(3, mod: -5)     // -2      -- a negative modulus, negative result
+```
+
+**A negative exponent raises the modular inverse**, by the extended Euclidean
+algorithm — so `power(-1, mod:)` *is* the inverse:
+
+```swift
+BigInt(2).power(-1, mod: 5)     // 3   -- because 2*3 == 6 ≡ 1 (mod 5)
+BigInt(3).power(-3, mod: 7)     // 6
+BigInt(-3).power(-1, mod: 7)    // 2   -- -3 ≡ 4, and 4*2 ≡ 1
+BigInt(2).power(-1, mod: 4)     // traps: 2 and 4 are not coprime
+```
+
+**A zero modulus traps**, and a modulus of 1 leaves nothing behind — not even for
+an exponent of zero:
+
+```swift
+BigInt(5).power(3, mod: 1)      // 0
+BigInt(2).power(0, mod: 5)      // 1
+BigInt(2).power(0, mod: 1)      // 0
+```
+
+### Exponents wider than an `Int`
+
+The exponent may also be a `Self`, which is the form cryptography needs — an RSA
+exponent is as wide as its modulus:
+
+```swift
+let p = BigInt(1) << 127 - 1                  // a Mersenne prime
+BigInt(3).power(p - 1, mod: p)                // 1, by Fermat's little theorem
+BigUInt(3).power(BigUInt(1) << 100, mod: 1000000007)   // 870513414
+```
+
+A 2048-bit modexp with a 2048-bit exponent runs in tens of milliseconds in a
+release build. There is deliberately no `power(_: Self)` without a modulus to match: an exponent
+past `Int` has no representable answer there, since the result would want more
+bits than the machine has.
+
 ## Conversions
 
 ```swift
@@ -280,6 +343,8 @@ public protocol BigIntegerType : BinaryInteger, LosslessStringConvertible, Codab
     init?<S: StringProtocol>(_ text: S, radix: Int)
     func squareRoot() -> Self
     func power(_ exponent: Int) -> Self
+    func power(_ exponent: Int, mod modulus: Self) -> Self
+    func power(_ exponent: Self, mod modulus: Self) -> Self
     func greatestCommonDivisor(with other: Self) -> Self
 }
 
@@ -288,7 +353,9 @@ public protocol BigIntType  : BigIntegerType, SignedInteger where Magnitude : Bi
 ```
 
 `BigIntegerType` adds the operations `BinaryInteger` lacks; the other two say
-nothing further. All six are implemented generically in an extension, so a new
+nothing further. All of them are implemented generically in an extension, so a new
 conformer gets a working version of each for free and overrides only what is worth
 specializing — which is what `BigInt` and `BigUInt` do for `squareRoot()` and
-`greatestCommonDivisor(with:)`.
+`greatestCommonDivisor(with:)`. The three `power`s share a single
+square-and-multiply loop, which takes the modulus as an `Optional` and reduces
+after each step when it has one.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Arbitrary-precision arithmetic for Swift, in Swift — **with no dependencies**.
 import BigNum
 
 BigInt(2).power(256)            // 115792089237316195423570985008687907853269984665640564039457584007913129639936
+BigInt(3).power(BigInt(1) << 100, mod: 1000000007)  // 870513414 -- Python's pow(b, e, m)
 1.over(3) + 1.over(6)           // (1/2) -- `over` turns two integers into a fraction
 BigRat(1,3) + BigRat(1,3) + BigRat(1,3) == 1    // true.  Not "true to 17 digits".
 BigFloat.sqrt(2)                // 1.414213562373095048801688724209698078569

--- a/Sources/BigNum/BigIntType.swift
+++ b/Sources/BigNum/BigIntType.swift
@@ -29,6 +29,11 @@ public protocol BigIntegerType : BinaryInteger, LosslessStringConvertible, Codab
     func squareRoot() -> Self
     /// `self` raised to `exponent`.
     func power(_ exponent: Int) -> Self
+    /// `self` raised to `exponent`, reduced modulo `modulus` -- Python's
+    /// three-argument `pow()`.
+    func power(_ exponent: Int, mod modulus: Self) -> Self
+    /// The same, for an exponent too wide to be an `Int`.
+    func power(_ exponent: Self, mod modulus: Self) -> Self
     /// The greatest common divisor of `self` and `other`, always non-negative.
     func greatestCommonDivisor(with other: Self) -> Self
 }
@@ -153,8 +158,36 @@ extension BigIntegerType {
 // MARK: - the arithmetic that only needs BinaryInteger
 
 extension BigIntegerType {
-    /// Square-and-multiply.  A negative `exponent` has no integral answer, so it
-    /// yields 0 except for the two values that are their own reciprocal.
+    /// Square-and-multiply, shared by every `power`.  With a `modulus` each
+    /// intermediate is reduced as it is formed, so nothing grows past twice the
+    /// modulus's width; without one the products run free.
+    ///
+    /// `exponent` is generic so a modular exponent can be a big integer while an
+    /// ordinary one stays an `Int`, and it is taken non-negative -- the callers
+    /// have dealt with the sign already.  `modulus`, when given, must be
+    /// positive, and `self` must already be reduced into `0 ..< modulus`.
+    internal func _squareAndMultiply<E:BinaryInteger>(_ exponent: E, mod modulus: Self?) -> Self {
+        var result = Self(1)
+        // 1 is not reduced when the modulus is 1, and an exponent of 0 returns
+        // it untouched -- so reduce up front rather than special-casing that.
+        if let m = modulus { result %= m }
+        var (base, n) = (self, exponent)
+        while n > 0 {
+            if n & 1 == 1 {
+                result *= base
+                if let m = modulus { result %= m }
+            }
+            n >>= 1
+            if n > 0 {
+                base *= base
+                if let m = modulus { base %= m }
+            }
+        }
+        return result
+    }
+
+    /// A negative `exponent` has no integral answer, so it yields 0 except for
+    /// the two values that are their own reciprocal.
     public func power(_ exponent: Int) -> Self {
         if exponent == 0 { return 1 }
         if exponent == 1 { return self }
@@ -166,12 +199,75 @@ extension BigIntegerType {
             if Self.isSigned && self == 0 - 1 { return exponent % 2 == 0 ? 1 : self }
             return 0
         }
-        var (result, base, n) = (Self(1), self, exponent)
-        while n > 0 {
-            if n & 1 == 1 { result *= base }
-            n >>= 1
-            if n > 0 { base *= base }
+        return self._squareAndMultiply(UInt(exponent), mod: nil)
+    }
+
+    /// `self`⁻¹ mod `modulus` by the extended Euclidean algorithm, or nil when
+    /// the two are not coprime and no inverse exists.  `modulus` must be
+    /// positive and `self` reduced into `0 ..< modulus`.
+    ///
+    /// The Bézout coefficient is carried reduced modulo `modulus` rather than as
+    /// the signed value the textbook tracks, which keeps every intermediate
+    /// non-negative -- an unsigned `Self` could not hold the signed form.
+    internal func _inverse(mod modulus: Self) -> Self? {
+        var (r, nextR) = (self, modulus)
+        var (s, nextS) = (Self(1) % modulus, Self(0))    // self * s ≡ r (mod modulus)
+        while !nextR.isZero {
+            let q = r / nextR
+            (r, nextR) = (nextR, r - q * nextR)
+            let qs = ((q % modulus) * nextS) % modulus
+            (s, nextS) = (nextS, s >= qs ? s - qs : s + modulus - qs)
         }
+        return r == 1 ? s : nil
+    }
+
+    /// `self` raised to `exponent`, reduced modulo `modulus` -- Python's
+    /// three-argument `pow()`, with the same three conventions:
+    ///
+    /// * The result carries the **sign of `modulus`**, so it lands in
+    ///   `0 ..< modulus` for a positive one.  That is a floored remainder, not
+    ///   the truncated one `%` gives: `BigInt(-2).power(3, mod:5)` is 2, where
+    ///   `BigInt(-2).power(3) % 5` is -3.
+    /// * A **negative `exponent`** raises the modular inverse of `self`, so
+    ///   `x.power(-1, mod:m)` *is* that inverse.  It traps when `self` and
+    ///   `modulus` are not coprime, there being no inverse to return.
+    /// * A **zero `modulus`** traps.
+    ///
+    /// Only the modulus bounds the intermediates, so this stays cheap where
+    /// `power(_:)` could not run at all: `e` squarings of a value no wider than
+    /// `modulus`, rather than a result with `e * self.bitWidth` bits.
+    public func power(_ exponent: Int, mod modulus: Self) -> Self {
+        return self._power(exponent, mod: modulus)
+    }
+
+    /// `power(_:mod:)` for an exponent too large to be an `Int`, which is the
+    /// usual case in cryptography -- an RSA exponent is as wide as its modulus.
+    ///
+    /// There is deliberately no `power(_: Self)` to match: without a modulus an
+    /// exponent past `Int` has no representable answer anyway, since the result
+    /// would need more bits than the machine has.
+    public func power(_ exponent: Self, mod modulus: Self) -> Self {
+        return self._power(exponent, mod: modulus)
+    }
+
+    /// The two `power(_:mod:)`s, differing only in how wide an exponent they let
+    /// you write.
+    internal func _power<E:BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self {
+        precondition(!modulus.isZero, "power(_:mod:) with a modulus of zero")
+        // Work in |modulus| throughout and put the sign back at the end.  The
+        // `< 0` tests all fold away for an unsigned `Self`, which could not
+        // evaluate `0 - modulus` anyway.
+        let m = modulus < 0 ? 0 - modulus : modulus
+        var base = self % m
+        if base < 0 { base += m }
+        if exponent < 0 {
+            guard let inverse = base._inverse(mod: m) else {
+                preconditionFailure("\(self) has no inverse modulo \(modulus)")
+            }
+            base = inverse
+        }
+        var result = base._squareAndMultiply(exponent.magnitude, mod: m)
+        if modulus < 0 && !result.isZero { result -= m }
         return result
     }
 

--- a/Tests/BigNumTests/BigIntTests.swift
+++ b/Tests/BigNumTests/BigIntTests.swift
@@ -420,6 +420,140 @@ import Foundation   // JSONEncoder, for the Codable round trip
         #expect(BigInt(0).squareRoot() == 0)
     }
 
+    // MARK: - modular exponentiation
+
+    /// The expected values here are Python's `pow(b, e, m)`, which is what
+    /// `power(_:mod:)` is meant to agree with.
+    @Test func powerModEdges() {
+        #expect(BigInt(2).power(10, mod: 1000) == 24)
+        #expect(BigInt(123456789).power(12345, mod: 1000000007) == 614455772)
+        #expect(BigUInt(2).power(10, mod: 1000) == 24)
+        // a modulus of 1 leaves nothing behind, not even for an exponent of 0
+        #expect(BigInt(2).power(0, mod: 1) == 0)
+        #expect(BigInt(5).power(3, mod: 1) == 0)
+        #expect(BigUInt(2).power(1, mod: 1) == 0)
+        #expect(BigInt(2).power(0, mod: 5) == 1)
+        #expect(BigInt(0).power(0, mod: 5) == 1)     // 0^0 is 1, as everywhere
+        #expect(BigInt(0).power(7, mod: 5) == 0)
+        // the result takes the sign of the modulus -- a floored remainder, not
+        // the truncated one `%` would give
+        #expect(BigInt(-2).power(3, mod: 5) == 2)
+        #expect(BigInt(-2).power(3) % 5 == -3)       // ... and this is the difference
+        #expect(BigInt(-2).power(2, mod: 5) == 4)
+        #expect(BigInt(2).power(3, mod: -5) == -2)
+        #expect(BigInt(-2).power(3, mod: -5) == -3)
+        #expect(BigInt(7).power(4, mod: -3) == -2)
+        #expect(BigInt(7).power(4, mod: 3) == 1)
+        // a negative exponent is the modular inverse
+        #expect(BigInt(2).power(-1, mod: 5) == 3)    // 2*3 == 6 ≡ 1
+        #expect(BigInt(3).power(-3, mod: 7) == 6)
+        #expect(BigInt(2).power(-5, mod: 7) == 2)
+        #expect(BigInt(10).power(-1, mod: 3) == 1)
+        #expect(BigInt(-3).power(-1, mod: 7) == 2)   // -3 ≡ 4, and 4*2 ≡ 1
+        #expect(BigInt(1).power(-1, mod: 1) == 0)
+        // exactly at a limb boundary
+        #expect(BigInt(2).power(64, mod: BigInt(1) << 64) == 0)
+        #expect(BigUInt(2).power(64, mod: (BigUInt(1) << 64) + 13) == BigUInt(1) << 64)
+    }
+
+    /// Repeated multiplication in `Int`: no square-and-multiply, no bignum, no
+    /// shared idea with what it is checking.  Needs `0 < m` small enough that
+    /// `r * base` cannot overflow, and a non-negative exponent.
+    func powModOracle(_ b:Int, _ e:Int, _ m:Int) -> Int {
+        let base = ((b % m) + m) % m
+        var r = 1 % m
+        for _ in 0 ..< e { r = r * base % m }
+        return r
+    }
+
+    @Test func powerModAgainstRepeatedMultiplication() {
+        for m in [1, 2, 3, 7, 10, 97, 1000, 65537] {
+            for b in -20 ... 20 {
+                for e in 0 ... 24 {
+                    let want = powModOracle(b, e, m)
+                    #expect(BigInt(b).power(e, mod: BigInt(m)) == BigInt(want),
+                            "\(b)^\(e) mod \(m)")
+                    #expect(BigInt(b).power(BigInt(e), mod: BigInt(m)) == BigInt(want),
+                            "\(b)^\(e) mod \(m), wide exponent")
+                    // a negative modulus shifts the answer down by |m| unless
+                    // it is zero, which is its own residue either way
+                    let negWant = want == 0 ? 0 : want - m
+                    #expect(BigInt(b).power(e, mod: BigInt(-m)) == BigInt(negWant),
+                            "\(b)^\(e) mod \(-m)")
+                    if b >= 0 {
+                        #expect(BigUInt(b).power(e, mod: BigUInt(m)) == BigUInt(want),
+                                "unsigned \(b)^\(e) mod \(m)")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(arguments: seeds)
+    func powerModAgainstPlainPower(_ seed:UInt64) {
+        var rng = Random(seed: seed)
+        // Where `power(_:)` can still be computed, the two have to agree once
+        // the sign convention is accounted for.
+        for _ in 0 ..< 300 {
+            let b = rng.big(limbs: 2)
+            let m = rng.big(limbs: 1)
+            if m.isZero { continue }
+            let e = Int(rng.uint() % 40)
+            var want = b.power(e) % m
+            if want.isNegative != m.isNegative && !want.isZero { want += m }
+            #expect(b.power(e, mod: m) == want, "\(b)^\(e) mod \(m)")
+        }
+    }
+
+    /// `power(-1, mod:)` traps when there is no inverse to return, and a trap
+    /// cannot be `#expect`ed -- so the coprimality test is checked one level
+    /// down, where it still has a `nil` to give back.
+    @Test func modularInverseRejectsNonCoprime() {
+        #expect(BigInt(2)._inverse(mod: 4) == nil)
+        #expect(BigInt(6)._inverse(mod: 9) == nil)
+        #expect(BigInt(0)._inverse(mod: 5) == nil)
+        #expect(BigUInt(4)._inverse(mod: 8) == nil)
+        #expect(BigUInt(0)._inverse(mod: 6) == nil)
+        #expect(BigInt(0)._inverse(mod: 1) == 0)     // everything is 0 mod 1
+        // Exhaustively: an inverse exists exactly when the two are coprime, and
+        // when it exists it is the one `power(-1, mod:)` hands back.
+        // 256 for a modulus sharing factors with half its residues, 1021 for a
+        // prime where every non-zero residue must have an inverse
+        for m in [1, 2, 3, 7, 10, 97, 256, 1021] {
+            for a in 0 ..< m {
+                let inv = BigInt(a)._inverse(mod: BigInt(m))
+                let coprime = gcdOracle(UInt(a), UInt(m)) == 1
+                #expect((inv != nil) == coprime, "inverse of \(a) mod \(m)")
+                guard let inv = inv else { continue }
+                #expect(BigInt(a) * inv % BigInt(m) == 1 % BigInt(m),
+                        "\(a) * \(inv) should be 1 mod \(m)")
+                #expect(BigInt(a).power(-1, mod: BigInt(m)) == inv,
+                        "power(-1, mod:\(m)) of \(a)")
+            }
+        }
+    }
+
+    /// Fermat's little theorem is the one check that needs an exponent wider
+    /// than an `Int`: for a prime `p` and `a` not a multiple of it,
+    /// `a^(p-1) ≡ 1`.  2^61-1 and 2^127-1 are Mersenne primes.
+    @Test func powerModWideExponent() {
+        for bits in [61, 127] {
+            let p = BigInt(1) << bits - 1
+            for a in [BigInt(2), BigInt(3), BigInt(-7), p - 1, p << 3 | 5] {
+                #expect(a.power(p - 1, mod: p) == 1, "\(a)^(2^\(bits)-2) mod 2^\(bits)-1")
+                // and the inverse a negative exponent gives really is one
+                let inv = a.power(-1, mod: p)
+                #expect((a % p + p) % p * inv % p == 1, "\(a)^-1 mod 2^\(bits)-1")
+                // a^-1 == a^(p-2) for a prime modulus, by Fermat again
+                #expect(inv == a.power(p - 2, mod: p), "two routes to the inverse")
+            }
+        }
+        // the unsigned form takes a wide exponent too
+        let n = (BigUInt(1) << 127) - 1
+        #expect(BigUInt(3).power(n - 1, mod: n) == 1)
+        #expect(BigUInt(3).power(BigUInt(1) << 100, mod: 1000000007) == 870513414)
+    }
+
     // MARK: - strings
 
     @Test(arguments: seeds)

--- a/macOS.playground/Pages/BigInt.xcplaygroundpage/Contents.swift
+++ b/macOS.playground/Pages/BigInt.xcplaygroundpage/Contents.swift
@@ -66,6 +66,29 @@ let m127 = BigInt(2).power(127) - 1
 m127                                // 170141183460469231731687303715884105727
 m127.description.count              // 39 digits
 
+//: ## Modular exponentiation -- `power(_:mod:)`, Python's three-argument `pow()`.
+//: Intermediates are reduced as they are formed, so nothing ever grows past
+//: twice the modulus's width.
+BigInt(2).power(10, mod: 1000)                      // 24
+BigInt(123456789).power(12345, mod: 1000000007)
+BigInt(2).power(1000000, mod: 7)    // instant; `power(1000000) % 7` would not be
+
+//: The result takes the sign of the modulus -- a floored remainder, where `%`
+//: gives a truncated one
+BigInt(-2).power(3, mod: 5)         //  2
+BigInt(-2).power(3) % 5             // -3, the same value in the other convention
+BigInt(2).power(3, mod: -5)         // -2
+
+//: A negative exponent raises the modular inverse
+BigInt(2).power(-1, mod: 5)         // 3, because 2*3 == 6 ≡ 1 (mod 5)
+BigInt(3).power(-3, mod: 7)         // 6
+//: BigInt(2).power(-1, mod: 4)     // would trap: 2 and 4 share a factor
+
+//: The exponent can be a BigInt too, which is what a Fermat test needs.  If
+//: m127 were composite this would almost certainly not be 1.
+BigInt(3).power(m127 - 1, mod: m127)            // 1
+BigInt(3).power(BigInt(1) << 100, mod: 1000000007)
+
 //: ## Strings and conversions
 BigInt(255).toString(radix:16)
 BigInt(255).toString(radix:16, uppercase:true)


### PR DESCRIPTION
## What

`power(_:mod:)` on `BigIntegerType`, so `BigInt`, `BigUInt` and any future conformer get modular exponentiation.

```swift
BigInt(2).power(10, mod: 1000)                     // 24
BigInt(123456789).power(12345, mod: 1000000007)    // 614455772
```

## Why

`power(_:)` cannot answer a modular question. `power(e) % m` builds the whole of `self^e` first, which is unrepresentable for any exponent worth reducing — `BigInt(2).power(1000000, mod: 7)` is instant where `BigInt(2).power(1000000) % 7` constructs a million-bit number. Reducing as we go costs one squaring per exponent bit and keeps every intermediate under twice the modulus's width.

## Design notes for the reviewer

**Two overloads, differing only in how wide an exponent they take.** `Int` matches the existing `power(_:)`, but a 63-bit cap would rule out the main use for modular exponentiation — an RSA or Diffie-Hellman exponent is as wide as its modulus — and Python's `pow` accepts arbitrary big exponents. So a `Self` exponent is allowed too:

```swift
let p = BigInt(1) << 127 - 1                   // a Mersenne prime
BigInt(3).power(p - 1, mod: p)                 // 1, by Fermat's little theorem
```

There is deliberately no `power(_: Self)` without a modulus to match: an exponent past `Int` has no representable answer there anyway. A 2048-bit modexp with a 2048-bit exponent runs in ~50 ms in a release build.

**Python's three conventions**, since that is the stated reference:

- the result takes the **sign of the modulus** — a floored remainder, so `BigInt(-2).power(3, mod: 5)` is `2` where `BigInt(-2).power(3) % 5` is `-3`
- a **negative exponent** raises the modular inverse, by extended Euclid, so `power(-1, mod:)` *is* the inverse
- a **zero modulus** traps, and a modulus of 1 leaves nothing behind even for an exponent of 0

**One loop, three entry points.** Rather than `power(_:mod:)` calling `power(_:)`, both now go through `_squareAndMultiply`, which takes the modulus as an `Optional` and reduces after each step when it has one. No measurable cost to the plain path — the suite runs in 8.0 s, same as before.

**The inverse carries its Bézout coefficient reduced modulo the modulus** rather than as the signed value the textbook tracks, because an unsigned `Self` could not hold the signed form and `BigUInt` shares this code.

## Testing

Four properties, each against an oracle that shares no idea with the implementation:

- repeated multiplication in `Int` — no square-and-multiply, no bignum
- `power(_:)` composed with `%`, sign convention accounted for
- Fermat's little theorem for 2^61-1 and 2^127-1, the only check that needs an exponent wider than an `Int`
- an exhaustive coprimality check of `_inverse` against Euclid's gcd

Four mutations confirm the tests bite. One initially did not: deleting the coprimality check from the inverse passed everything, because that path traps and a trap cannot be `#expect`ed. It is now tested at `_inverse`, one level down, where it still returns `nil`.

Separately, and not part of the suite, the implementation was checked against **Python's own `pow`** over 657 generated cases — negative bases, negative moduli, negative exponents, moduli of 1, limb boundaries, and exponents up to 400 bits — with no mismatches. Both documented traps were confirmed to trap, and 2^127-1 was confirmed prime by Miller-Rabin before the docs called it so.

46 tests pass (2 pre-existing known issues, both the `atan2(-0, x)` sign-of-zero gap). All six playground pages recompile and run.

## Docs

New "modular exponentiation" section in `BigInt.md`, a line in the README synopsis, and a block on the BigInt playground page that reuses the `m127` already sitting there as "a Mersenne prime candidate" for a Fermat test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)