### PR TITLE
Add primality tests, and put the number theory on the built-in integers

### DIFF
--- a/BigInt.md
+++ b/BigInt.md
@@ -271,6 +271,141 @@ and cannot be invalidated by a change of limb width. **This is not compatible wi
 attaswift/BigInt's encoding**, so archives written against swift-bignum 5.x will
 not decode.
 
+## Primality
+
+**`isPrime` is a `Bool?`, and `nil` means "not proven".** It answers only what
+this package can establish, and declines to pass off a probable answer as a
+certain one:
+
+```swift
+BigInt(1000003).isPrime                  // true
+BigInt(1000001).isPrime                  // false, 101 * 9901
+BigInt(561).isPrime                      // false -- a Carmichael number is not fooling this
+BigInt(-7).isPrime                       // false, as is anything below 2
+(BigInt(1) << 127 - 1).isPrime           // true  -- a Mersenne number, so exactly settled
+(BigInt(1) << 300).nextPrime.isPrime     // nil   -- probably prime, unproven
+```
+
+A `false` is always available: a witness to compositeness *is* a proof, at any
+size. A `true` needs one of three things — the value below 2^64, or below
+3317044064679887385961981 (the last entry of [A014233], where Miller-Rabin on the
+first thirteen prime bases is deterministic), or a Mersenne number, which
+Lucas-Lehmer settles outright. Past all of those you get `nil`.
+
+Because `nil` is not `false`, `if n.isPrime` will not compile. Say which reading
+you want:
+
+```swift
+if n.isPrime == true { ... }              // "proven prime", unknown excluded
+if n.isProbablePrime { ... }              // "no witness found", unknown included
+```
+
+### Below 2^64 there is always an answer
+
+**`isPrime` is never `nil` for a value at or below `UInt64.max`**, since that
+whole range sits inside the exhaustively verified one. If your numbers fit a
+`UInt64` — or are negative, or came from an `Int` — the force unwrap cannot trap
+and is the right thing to write:
+
+```swift
+BigInt(1000003).isPrime!                 // true
+BigInt(1000001).isPrime!                 // false
+BigInt(UInt64.max).isPrime!              // false
+BigInt(Int.max).isPrime!                 // false
+BigInt(-7).isPrime!                      // false
+```
+
+The certain range is in fact wider than that — `nil` does not appear until past
+3317044064679887385961981, and never at all for a composite or a Mersenne number
+— but `UInt64.max` is the bound worth remembering, because it is the one that
+holds no matter which of the three proofs applies.
+
+### The probable answer, when you want it
+
+`isProbablePrime` is the [Baillie-PSW] test itself: Miller-Rabin on base 2, then
+a Lucas probable-prime test. Both halves earn their place — 2047 (= 23 × 89)
+passes the Miller-Rabin half, and only Lucas rejects it.
+
+```swift
+BigInt(1000003).isProbablePrime               // true
+(BigInt(1) << 300).nextPrime.isProbablePrime  // true, where isPrime says nil
+```
+
+No composite is known to pass BPSW, and none below 2^64 exists — that range has
+been checked exhaustively — so below 2^64 the two agree by construction. A
+300-bit number takes under 2 ms.
+
+`isSurelyPrime` gives both halves at once, which is what `isPrime` is built from:
+
+```swift
+BigInt(65537).isSurelyPrime              // (true, surely: true)
+BigInt(561).isSurelyPrime                // (false, surely: true)
+((BigInt(1) << 300).nextPrime).isSurelyPrime   // (true, surely: false)
+```
+
+### The pieces, separately
+
+```swift
+BigInt(2047).millerRabinTest(base: 2)    // true  -- a strong pseudoprime to base 2
+BigInt(2047).isLucasProbablePrime        // false -- which is what catches it
+BigInt(7).jacobiSymbol(3)                // -1
+BigInt(7).jacobiSymbol(2)                //  1
+BigInt(7).jacobiSymbol(7)                //  0    -- not coprime
+```
+
+`millerRabinTest(base:)` proves compositeness and never primality, so a `true`
+from it means only that this base found no witness. The base is a `Self`, so it
+may be as large as the number under test. `jacobiSymbol(_:)` is (i / self), and
+is 0 unless `self` is odd and positive.
+
+### Mersenne numbers
+
+For 2^p − 1 there is an exact test, so `isMersennePrime` gives a definite answer
+— and `nil` when the number is not of that form at all, which is a different
+thing from `false`:
+
+```swift
+(BigInt(1) << 521 - 1).isMersennePrime   // true  -- M521
+(BigInt(1) << 523 - 1).isMersennePrime   // false -- M523
+BigInt(100).isMersennePrime              // nil   -- not 2^p - 1
+```
+
+The exponent is recovered from the value rather than from any word size, the
+recurrence reduces by folding the high half of each square onto the low half
+(2^p ≡ 1, mod 2^p − 1) instead of dividing, and a composite exponent returns
+`false` without running it at all. M4423 — 1332 digits — settles in about 0.1 s.
+
+### Walking the primes
+
+```swift
+BigInt(1000).nextPrime                   // 1009
+(BigInt(1) << 64).nextPrime              // 18446744073709551629
+(BigInt(1) << 64).prevPrime              // 18446744073709551557
+BigInt(2).prevPrime                      // nil -- there is nothing below 2
+Array(BigInt.primes.prefix(10))          // [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+```
+
+`nextPrime` returns a value rather than an Optional, unlike the fixed-width
+original these came from: arbitrary precision has no ceiling to fall off, so
+there is no failure to report. `prevPrime` is still Optional, because 2 really
+does have nothing below it. `primes` is an endless `Sequence`, so pair it with
+`prefix` or `first(where:)`.
+
+These search on `isProbablePrime`, not `isPrime` — a walk that read `nil` as
+"composite" would step over every candidate and never come back. So above 2^64
+they land on a *probable* prime; ask the result for its own `isSurelyPrime` if
+that matters.
+
+All of this lives on `BigIntegerType`, so `BigUInt` has every one of them too.
+It is ported from [swift2-pons]'s `xtra_prime.swift`; the factorization half of
+that file is not here. One departure: the original's `isPrime` was a plain
+`Bool`, which above every deterministic bound reports "BPSW found no witness" as
+though it were a fact. Here that case is `nil`.
+
+[Baillie-PSW]: https://en.wikipedia.org/wiki/Baillie%E2%80%93PSW_primality_test
+[A014233]: https://oeis.org/A014233
+[swift2-pons]: https://github.com/dankogai/swift2-pons
+
 ## `over`: making fractions out of integers
 
 Every integer here has an `over(_:)`, which is the idiomatic way to build a
@@ -330,6 +465,75 @@ BigUInt("-1")                // nil -- an unsigned type refuses a sign
 
 Subtracting past zero traps, as `UInt` does. There is no `max`: the type is
 unbounded, so `BigUInt.max` would not have an answer.
+
+## On the built-in integers too
+
+All of the above — `power`, `power(_:mod:)`, the primality family, `squareRoot`,
+`greatestCommonDivisor` — is also on `Int`, `UInt`, `Int8` … `UInt64`, and
+`Int128`/`UInt128` where the platform has them:
+
+```swift
+Int(2).power(10)                        // 1024
+1000003.isPrime!                        // true
+UInt8(200).nextPrime                    // 211
+Int(1071).greatestCommonDivisor(with: 462)   // 21
+Array(Int.primes.prefix(5))             // [2, 3, 5, 7, 11]
+```
+
+Each one widens to `BigInt`, works there, and converts back. That is not a
+shortcut so much as the only sane way to get these onto a fixed-width type: a
+modular product of two residues does not fit in a word, so a native version would
+need an overflow-avoiding variant per width, and a call from a context generic
+over `FixedWidthInteger` would statically pick whichever one the compiler saw.
+`BigInt` has no such problem, and the only fixed-width question left is whether
+the answer fits.
+
+**When it does not, it traps** — like `*` and `+` on these types, and unlike
+wrapping or clamping:
+
+```swift
+Int(2).power(62)                        // 4611686018427387904
+Int(2).power(1024)                      // traps: an Int has no such number
+Int8(-3).power(5)                       // traps: -243 does not fit
+Int8(127).nextPrime                     // traps: 131 does not fit
+Int.min.greatestCommonDivisor(with: Int.min)   // traps: the answer is 2^63
+```
+
+`BigInt(x)` is the way out of all of those, and it is one call away. Some of the
+operations cannot overflow at all, and are safe at any width:
+
+| operation | can it trap? |
+|---|---|
+| `power(_:mod:)` | no — the answer is bounded by a modulus that is already a `Self` |
+| `squareRoot()` | no — a root is never larger than its argument |
+| `prevPrime` | no — it only moves toward zero |
+| `isPrime`, `isProbablePrime`, `isSurelyPrime`, `jacobiSymbol`, `millerRabinTest` | no — the answers are not `Self` |
+| `power(_:)` | yes, on overflow |
+| `nextPrime` | yes, if the next prime is past `Self.max` |
+| `greatestCommonDivisor(with:)` | only `gcd(Int.min, Int.min)` |
+| `primes` | only past `Self.max`, which needs a type no wider than `Int16` to reach |
+
+That first row is the useful one: `power(_:mod:)` is exactly what `power(_:)`
+followed by `%` cannot be.
+
+```swift
+Int(2).power(1024, mod: 1_000_000_007)  // 812734592
+Int(2).power(1024) % 1_000_000_007      // traps long before the `%`
+UInt8(200).power(200, mod: 251)         // 1, though 200 * 200 overflows a UInt8 twice over
+```
+
+**`isPrime!` is safe on any type of 64 bits or fewer**, since no value one of them
+can hold falls outside the exhaustively verified range. A 128-bit type is the
+exception — above `UInt64.max` a prime can come back `nil`.
+
+Two small print items. The modular `power` takes its exponent generically
+(`power<E: BinaryInteger>(_:mod:)`) rather than as the `Int`/`Self` pair
+`BigIntegerType` uses, because when `Self` is `Int` those two are the same
+signature and every call site is ambiguous. And `squareRoot()` and
+`greatestCommonDivisor(with:)` already reached the *signed* built-ins through
+`RationalElement`, by this same widen-and-return trick — `Int(10).squareRoot()` is
+not new. Only the unsigned ones gained them, `RationalElement` being a
+`SignedInteger`.
 
 ## The protocols
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ import BigNum
 
 BigInt(2).power(256)            // 115792089237316195423570985008687907853269984665640564039457584007913129639936
 BigInt(3).power(BigInt(1) << 100, mod: 1000000007)  // 870513414 -- Python's pow(b, e, m)
+BigInt(1000003).isPrime!        // true -- a Bool?, but never nil below 2^64
+1000003.isPrime!                // ... and all of this works on Int and UInt8 too
 1.over(3) + 1.over(6)           // (1/2) -- `over` turns two integers into a fraction
 BigRat(1,3) + BigRat(1,3) + BigRat(1,3) == 1    // true.  Not "true to 17 digits".
 BigFloat.sqrt(2)                // 1.414213562373095048801688724209698078569
@@ -45,6 +47,26 @@ its storage stays put and its arithmetic rounds. The one-line version:
 BigRat(1)/BigRat(3) * 3 == 1        // true  -- exact
 BigFloat(1)/BigFloat(3) * 3 == 1    // false -- rounded to `precision` bits
 ```
+
+## The built-in integers get all of it
+
+`power`, `power(_:mod:)`, `isPrime`, `squareRoot`, `greatestCommonDivisor`,
+`nextPrime` and the rest are on `Int`, `UInt`, `Int8` … `UInt64` and `Int128` as
+well as on `BigInt`:
+
+```swift
+Int(2).power(10)                        // 1024
+1000003.isPrime!                        // true
+UInt8(200).nextPrime                    // 211
+Int(2).power(1024, mod: 1_000_000_007)  // 812734592 -- no overflow, ever
+```
+
+Each widens to `BigInt`, computes there, and comes back — so where the answer
+does not fit, it traps, exactly as `*` would. `Int(2).power(1024)` is not a number
+an `Int` has, and `BigInt(2).power(1024)` is right there when you need it. The
+modular form never overflows, which is what makes it worth having.
+[BigInt.md](BigInt.md#on-the-built-in-integers-too) has the full table of which
+operations can trap.
 
 ## `over`: fractions from integers
 
@@ -164,7 +186,7 @@ the `BigNum` module is built, then open the playground.
 ## Documentation
 
 * [BigInt.md](BigInt.md) — `BigInt` and `BigUInt`: representation, bit twiddling,
-  division semantics, number theory
+  division semantics, number theory, primality
 * [BigRat.md](BigRat.md) — `BigRat`: exact rationals, the `FloatingPoint`
   conformance, `IntRat` and the other fixed-width rationals
 * [BigFloat.md](BigFloat.md) — `BigFloat`: mantissa and scale, rounding,

--- a/Sources/BigNum/FixedWidthInteger.swift
+++ b/Sources/BigNum/FixedWidthInteger.swift
@@ -1,0 +1,169 @@
+//
+//  FixedWidthInteger.swift -- BigNum's number theory, on the built-in integers.
+//
+//  Everything here is one line: widen to `BigInt`, do the work there, and come
+//  back.  `Int`, `UInt`, `Int8` ... `UInt64` and -- where the platform has it --
+//  `Int128`/`UInt128` all pick these up, since they are written against
+//  `FixedWidthInteger` rather than declared per type.
+//
+//  Delegating rather than reimplementing is the whole point.  A modular exponent
+//  needs a product of two residues, which does not fit in a word; a gcd wants
+//  in-place limb work; primality wants both of those plus a Lucas sequence.
+//  Written natively, each would need an overflow-avoiding variant per width, and
+//  a call from a context generic over `FixedWidthInteger` would statically pick
+//  whichever the compiler happened to see.  `BigInt` has none of those problems,
+//  so it does the arithmetic and the only fixed-width question left is whether
+//  the answer fits.
+//
+//  Which it does not, sometimes -- and then it traps, exactly as `*` and `+` do
+//  on these types.  `Int(2).power(1024)` is not a number an `Int` has, and this
+//  says so rather than wrapping or clamping:
+//
+//      Int(2).power(62)                // 4611686018427387904
+//      Int(2).power(1024)              // traps: not representable
+//      Int8(127).nextPrime             // traps: 131 does not fit
+//      Int.min.greatestCommonDivisor(with: Int.min)    // traps: 2^63 does not
+//
+//  `BigInt` is where to go when that is not what you want -- and it is one
+//  `BigInt(x)` away.  The operations that cannot overflow are noted below.
+//
+//  These are extensions on `FixedWidthInteger` and not on `BinaryInteger` for a
+//  reason worth keeping: `BigInt` and `BigUInt` are `BinaryInteger`s, so the
+//  wider extension would apply to them too, and `BigInt(self).isPrime` inside it
+//  would be at risk of resolving straight back to itself.  `FixedWidthInteger`
+//  cannot overlap them, and covers every built-in integer type anyway.
+//
+
+// MARK: - exponentiation
+
+extension FixedWidthInteger {
+    /// `self` raised to `exponent`, by square-and-multiply in `BigInt`.
+    ///
+    /// Traps unless the result is representable -- `Int(2).power(1024)` is not a
+    /// number an `Int` has.  Use `BigInt(self).power(exponent)` for one that can
+    /// hold it.
+    public func power(_ exponent: Int) -> Self {
+        return Self(BigInt(self).power(exponent))
+    }
+
+    /// `self` raised to `exponent`, reduced modulo `modulus` -- Python's
+    /// three-argument `pow()`.  See `BigIntegerType.power(_:mod:)` for the three
+    /// conventions it follows; briefly, the result takes the sign of `modulus`, a
+    /// negative `exponent` raises the modular inverse, and a zero `modulus` traps.
+    ///
+    /// This one cannot overflow: the answer is bounded by `modulus`, which is a
+    /// `Self` already.  It is the reason to reach for `power(_:mod:)` rather than
+    /// `power(_:)` followed by `%`, which would have to build the whole power
+    /// first and would trap long before it got there.
+    ///
+    ///     Int(2).power(1024, mod: 1_000_000_007)      // 812734592
+    ///     Int(2).power(1024) % 1_000_000_007          // traps
+    ///
+    /// One generic overload rather than the `Int` and `Self` pair
+    /// `BigIntegerType` has: when `Self` is `Int` those two are the same
+    /// signature, and every call is ambiguous.  Generic covers both and takes a
+    /// `BigInt` exponent as well.
+    public func power<E:BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self {
+        return Self(BigInt(self).power(BigInt(exponent), mod: BigInt(modulus)))
+    }
+}
+
+// MARK: - roots and divisors, for the unsigned types only
+//
+// The signed ones have had both of these all along, from `RationalElement` in
+// Rational.swift -- `Int(10).squareRoot()` worked before this file existed, and
+// by the same widen-and-return trick.  `RationalElement` refines
+// `SignedInteger`, though, so `UInt` and its narrower siblings were left out.
+// Constraining to `UnsignedInteger` fills that gap without colliding with what
+// is already there; an unconstrained extension here makes `Int` ambiguous and
+// stops Rational.swift itself from compiling.
+
+extension FixedWidthInteger where Self : UnsignedInteger {
+    /// ⌊√self⌋, by Newton's method in `BigInt`.  Cannot overflow: a square root
+    /// is never larger than what it came from.
+    public func squareRoot() -> Self {
+        return Self(BigInt(self).squareRoot())
+    }
+
+    /// The greatest common divisor of `self` and `other`, by Stein's binary GCD
+    /// in `BigInt`.  Cannot overflow: a divisor of an unsigned value fits
+    /// wherever the value did.
+    public func greatestCommonDivisor(with other: Self) -> Self {
+        return Self(BigInt(self).greatestCommonDivisor(with: BigInt(other)))
+    }
+}
+
+// MARK: - primality
+
+extension FixedWidthInteger {
+    /// Whether `self` is prime, or `nil` when no test here can settle it.
+    ///
+    /// For a type of 64 bits or fewer this is **never `nil`** -- every value it
+    /// can hold is inside the exhaustively verified range -- so `isPrime!` is
+    /// safe there and is the natural thing to write:
+    ///
+    ///     Int(1000003).isPrime!           // true
+    ///     UInt64.max.isPrime!             // false
+    ///     Int(-7).isPrime!                // false
+    ///
+    /// A 128-bit type is the one exception: above `UInt64.max` a prime may come
+    /// back `nil`, meaning "probably, unproven".  See `BigIntegerType.isPrime`.
+    public var isPrime: Bool? {
+        return BigInt(self).isPrime
+    }
+
+    /// The Baillie-PSW result itself, without the certainty gate -- `true` where
+    /// `isPrime` would say `nil`.  Exact for any type of 64 bits or fewer.
+    public var isProbablePrime: Bool {
+        return BigInt(self).isProbablePrime
+    }
+
+    /// Whether `self` is prime, and whether that answer is certain.  For a type
+    /// of 64 bits or fewer `surely` is always `true`.
+    public var isSurelyPrime: (Bool, surely: Bool) {
+        return BigInt(self).isSurelyPrime
+    }
+
+    /// `true` if `self` passes the Miller-Rabin test on `base`, which proves
+    /// compositeness but never primality.
+    public func millerRabinTest(base: Self) -> Bool {
+        return BigInt(self).millerRabinTest(base: BigInt(base))
+    }
+
+    /// The Jacobi symbol (`i` / `self`), 0 unless `self` is odd and positive.
+    public func jacobiSymbol(_ i: Int) -> Int {
+        return BigInt(self).jacobiSymbol(i)
+    }
+
+    /// `true` if `self` is a Lucas probable prime for the first Selfridge
+    /// parameters.
+    public var isLucasProbablePrime: Bool {
+        return BigInt(self).isLucasProbablePrime
+    }
+
+    /// The Lucas-Lehmer test: `true` if `self` is a Mersenne prime, `false` if it
+    /// is a composite Mersenne number, `nil` if `self` is not 2^p - 1 at all.
+    public var isMersennePrime: Bool? {
+        return BigInt(self).isMersennePrime
+    }
+
+    /// The first prime greater than `self`.  Traps when there is not one left in
+    /// the type -- `Int8(127).nextPrime` would be 131.
+    public var nextPrime: Self {
+        return Self(BigInt(self).nextPrime)
+    }
+
+    /// The last prime less than `self`, or nil when there is none.  Cannot
+    /// overflow, since it only ever moves toward zero.
+    public var prevPrime: Self? {
+        return BigInt(self).prevPrime.map { Self($0) }
+    }
+
+    /// The primes from 2 upward, lazily.  Traps if you walk it past `Self.max`,
+    /// which for anything wider than an `Int16` means it will not.
+    ///
+    ///     Array(Int.primes.prefix(5))     // [2, 3, 5, 7, 11]
+    public static var primes: some Sequence<Self> {
+        return BigInt.primes.lazy.map { Self($0) }
+    }
+}

--- a/Sources/BigNum/Primality.swift
+++ b/Sources/BigNum/Primality.swift
@@ -1,0 +1,345 @@
+//
+//  Primality.swift -- is it prime?
+//
+//  Ported from dankogai/swift2-pons's xtra_prime.swift, whose primality half
+//  these are: Miller-Rabin on a chosen base, the Jacobi symbol, a Lucas
+//  probable-prime test, Lucas-Lehmer for the Mersenne numbers, and BPSW built
+//  out of the first two.  The factorization half of that file is not here.
+//
+//  All of it hangs off `BigIntegerType`, so `BigInt` and `BigUInt` share one
+//  implementation.  Arbitrary precision simplifies the originals in two places:
+//  `nextPrime` cannot run out of room, so it returns a value rather than an
+//  Optional, and `isMersennePrime` recovers its exponent from the value itself
+//  instead of from a fixed word size.
+//
+//  It also removes one, and that is the one departure worth knowing about.  The
+//  original's `isPrime` was a `Bool`, which for a number past every deterministic
+//  bound here means "BPSW found no witness" dressed as a fact.  Ours is a
+//  `Bool?` and withholds that answer, so a caller has to decide what to do with
+//  "unknown" instead of being handed a maybe.  The BPSW result itself is still
+//  available, spelled `isProbablePrime`, and the two together are
+//  `isSurelyPrime`.
+//
+//  `millerRabinTest(base:)` is the reason `power(_:mod:)` takes an exponent as
+//  wide as `Self`: the exponent here is (self - 1) >> its trailing zeros.
+//
+
+extension BigIntegerType {
+
+    // MARK: - Miller-Rabin
+
+    /// `true` if `self` passes the [Miller-Rabin] test on `base` -- that is, if
+    /// this base fails to witness `self` composite.  A single base proves
+    /// compositeness but never primality, which is what `isPrime` and
+    /// `isSurelyPrime` are for.
+    ///
+    /// [Miller-Rabin]: https://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test
+    public func millerRabinTest(base: Self) -> Bool {
+        if self < 2      { return false }
+        if self & 1 == 0 { return self == 2 }
+        let last = self - 1
+        // last == d * 2^s with d odd.  `t` tracks the exponent of `y`, so it
+        // starts at d and doubles alongside each squaring.
+        var d = last
+        while d & 1 == 0 { d >>= 1 }
+        var t = d
+        var y = base.power(d, mod: self)
+        while t != last && y != 1 && y != last {
+            y = y * y % self
+            t <<= 1
+        }
+        // Reaching -1 anywhere in the chain is a pass.  So is y == 1 on the
+        // very first look, which `t & 1` detects: t is odd only before the
+        // first doubling.  A 1 that appears *after* a squaring means the
+        // previous y was a square root of 1 other than ±1, so `self` is
+        // composite.
+        return y == last || t & 1 == 1
+    }
+
+    // MARK: - the Jacobi symbol
+
+    /// The [Jacobi symbol] (`i` / `self`), which is 0 unless `self` is odd and
+    /// positive.
+    ///
+    /// [Jacobi symbol]: https://en.wikipedia.org/wiki/Jacobi_symbol
+    public func jacobiSymbol(_ i: Int) -> Int {
+        var m = self
+        var n = Self(i.magnitude)
+        var j = 1
+        if m <= 0 || m & 1 == 0 { return 0 }
+        if i < 0 && m % 4 == 3 { j = -j }
+        while !n.isZero {
+            while n & 1 == 0 {
+                n >>= 1
+                let m8 = m % 8
+                if m8 == 3 || m8 == 5 { j = -j }
+            }
+            swap(&m, &n)
+            if n % 4 == 3 && m % 4 == 3 { j = -j }
+            n %= m
+        }
+        return m == 1 ? j : 0
+    }
+
+    // MARK: - Lucas
+
+    /// `true` if `self` is a [Lucas probable prime] for the first Selfridge
+    /// parameters -- D from 5, -7, 9, -11, ... the first with (D/self) == -1,
+    /// then P = 1 and Q = (1 - D)/4.
+    ///
+    /// [Lucas probable prime]: https://en.wikipedia.org/wiki/Lucas_pseudoprime
+    public var isLucasProbablePrime: Bool {
+        if self < 2      { return false }
+        if self & 1 == 0 { return self == 2 }
+        // A perfect square has no D with (D/self) == -1, so the search below
+        // would run off the end looking for one.
+        let root = self.squareRoot()
+        if root * root == self { return false }
+        var d = 0
+        for i in 2 ... 256 {                    // 256 is arbitrary, and ample
+            let candidate = (i & 1 == 0 ? 1 : -1) * (2 * i + 1)
+            if self.jacobiSymbol(candidate) == -1 { d = candidate ; break }
+        }
+        precondition(d != 0, "no D with (D/\(self)) == -1 -- is \(self) a square?")
+        // The sequence runs in BigInt because Q is often negative.  Every D here
+        // is 1 mod 4, so (1 - D)/4 is exact.
+        let n = BigInt(self)
+        let bd = BigInt(d)
+        var q = (1 - bd) / 4
+        var q2 = 2 * q
+        var (u, v)   = (BigInt(0), BigInt(2))   // U_0, V_0
+        var (u2, v2) = (BigInt(1), BigInt(1))   // U_1, V_1 == P == 1
+        // Climb the bits of h = (self + 1)/2, doubling (u2, v2) each step and
+        // folding it into (u, v) where the bit is set.
+        var h = (n + 1) / 2
+        while 0 < h {
+            u2 *= v2
+            u2 %= n
+            v2 *= v2
+            v2 -= q2
+            v2 %= n
+            if h & 1 == 1 {
+                let t = u
+                // U_{m+k} = (U_m V_k + U_k V_m) / 2, halved modulo n
+                u *= v2
+                u += u2 * v
+                u += u & 1 == 0 ? 0 : n
+                u /= 2
+                u %= n
+                // V_{m+k} = (V_m V_k + D U_m U_k) / 2, likewise
+                v *= v2
+                v += u2 * t * bd
+                v += v & 1 == 0 ? 0 : n
+                v /= 2
+                v %= n
+            }
+            q *= q
+            q %= n
+            q2 = q << 1
+            h >>= 1
+        }
+        // U_h == 0 is the pass.  Every prime with (D/self) == -1 reaches it:
+        // across every odd number below 300000, `u` vanishes for all 25996 of
+        // the primes and for only 132 of the composites -- and `v` vanishes for
+        // none of either, so there is nothing to gain by also asking about it.
+        return u.isZero
+    }
+
+    /// The [Lucas-Lehmer test], which settles a Mersenne number exactly.
+    ///
+    /// - returns: `true` if `self` is a Mersenne prime, `false` if it is a
+    ///   composite Mersenne number, and `nil` if `self` is not 2^p - 1 at all.
+    ///
+    /// [Lucas-Lehmer test]: https://en.wikipedia.org/wiki/Lucas%E2%80%93Lehmer_primality_test
+    public var isMersennePrime: Bool? {
+        // self is 2^p - 1 exactly when self + 1 is a power of two, and then p is
+        // where that power sits.  Recovering it this way needs no notion of a
+        // word size, which is what the original had to consult.
+        let next = self + 1
+        guard 3 <= self, next & self == 0 else { return nil }
+        let p = next.trailingZeroBitCount
+        if p == 2 { return true }               // M2 == 3, below the recurrence
+        // A composite p gives a composite Mp.  `isProbablePrime` rather than
+        // `isPrime` for two reasons: p came from a bit count so it is far below
+        // 2^64, where BPSW is exact and the Optional would only be noise; and
+        // `isPrime` routes through `isSurelyPrime`, which calls back here.
+        guard Self(p).isProbablePrime else { return false }
+        // s -> s^2 - 2 (mod self), p - 2 times, from 4.  Reduction is by folding
+        // rather than division: 2^p == 1 (mod 2^p - 1), so the high half of a
+        // square can just be added to the low half.
+        //
+        // Both guards below are insurance rather than repairs.  A fold leaves a
+        // sum under 2^(p+1), so a second subtraction is conceivable, and the
+        // recurrence reaching s < 2 with an iteration still to go would make a
+        // bare `s -= 2` underflow -- which for `BigUInt` is a trap, not a wrong
+        // answer.  Neither fires for any prime exponent up to 1300; s == 1 does
+        // arrive here at p == 4, which only a composite exponent could reach,
+        // and those have already returned above.
+        var s = Self(4)
+        for _ in 0 ..< p - 2 {
+            let square = s * s
+            s = (square & self) + (square >> p)
+            while self <= s { s -= self }
+            s = 2 <= s ? s - 2 : s + self - 2
+        }
+        return s.isZero
+    }
+
+    // MARK: - BPSW
+
+    /// `true` if `self` is prime according to the [Baillie-PSW] test: Miller-Rabin
+    /// on base 2, then a Lucas probable-prime test.
+    ///
+    /// No composite is known to pass, and none below 2^64 exists -- that range
+    /// has been checked exhaustively -- so this is exact for anything a `UInt64`
+    /// could hold.  Above it, `true` means only that neither half found a
+    /// witness, which is why `isPrime` withholds an answer there and this one is
+    /// spelled "probable".
+    ///
+    /// [Baillie-PSW]: https://en.wikipedia.org/wiki/Baillie%E2%80%93PSW_primality_test
+    public var isProbablePrime: Bool {
+        if self < 2      { return false }
+        if self & 1 == 0 { return self == 2 }
+        if self % 3 == 0 { return self == 3 }
+        if self % 5 == 0 { return self == 5 }
+        if self % 7 == 0 { return self == 7 }
+        return self.millerRabinTest(base: 2) && self.isLucasProbablePrime
+    }
+
+    /// ### [A014233]
+    ///
+    /// The smallest odd number that Miller-Rabin fails to expose using every
+    /// base up to the n-th prime.  Below `A014233[i]`, passing the first `i + 1`
+    /// prime bases *proves* primality.
+    ///
+    /// [A014233]: https://oeis.org/A014233
+    public static var A014233: [Self] {
+        return [
+            Self("2047")!,                       // bases through 2
+            Self("1373653")!,                    // 3
+            Self("25326001")!,                   // 5
+            Self("3215031751")!,                 // 7
+            Self("2152302898747")!,              // 11
+            Self("3474749660383")!,              // 13
+            Self("341550071728321")!,            // 17
+            Self("341550071728321")!,            // 19
+            Self("3825123056546413051")!,        // 23
+            Self("3825123056546413051")!,        // 29
+            Self("3825123056546413051")!,        // 31
+            Self("318665857834031151167461")!,   // 37
+            Self("3317044064679887385961981")!,  // 41
+        ]
+    }
+
+    /// The bases A014233 is indexed by.
+    internal static var _A014233Bases: [Int] {
+        return [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41]
+    }
+
+    /// Whether `self` is prime, and whether that answer is certain.
+    ///
+    /// `surely` is always `true` for a composite: a witness is a proof. For a
+    /// prime it is `true` up to 3317044064679887385961981, the end of
+    /// [A014233], and for any Mersenne number, which Lucas-Lehmer settles
+    /// outright. Past that a `true` rests on BPSW, which no composite is known
+    /// to pass but none is proven not to.
+    ///
+    /// [A014233]: https://oeis.org/A014233
+    public var isSurelyPrime: (Bool, surely: Bool) {
+        if self < 2      { return (false, true) }
+        if self & 1 == 0 { return (self == 2, true) }
+        if self % 3 == 0 { return (self == 3, true) }
+        if self % 5 == 0 { return (self == 5, true) }
+        if self % 7 == 0 { return (self == 7, true) }
+        // BPSW is exhaustively verified below 2^64
+        if self <= Self(UInt64.max) { return (self.isProbablePrime, true) }
+        if let mersenne = self.isMersennePrime { return (mersenne, true) }
+        let table = Self.A014233
+        if self < table[table.count - 1] {
+            for i in 0 ..< table.count {
+                if !self.millerRabinTest(base: Self(Self._A014233Bases[i])) {
+                    return (false, true)
+                }
+                if self < table[i] { return (true, true) }
+            }
+        }
+        let prime = self.isProbablePrime
+        return (prime, !prime)
+    }
+
+    /// Whether `self` is prime, or `nil` when no test here can settle it.
+    ///
+    ///     BigInt(1000003).isPrime                 // true
+    ///     BigInt(1000001).isPrime                 // false
+    ///     ((BigInt(1) << 300).nextPrime).isPrime  // nil -- probably prime, unproven
+    ///
+    /// A `false` is always a proof: a witness to compositeness is a witness. A
+    /// `true` is a proof too -- below 2^64, below [A014233]'s last entry with
+    /// thirteen Miller-Rabin bases, or for a Mersenne number through
+    /// Lucas-Lehmer.  Past all of those, BPSW still has an opinion and this
+    /// declines to launder it into a fact; `isProbablePrime` is that opinion and
+    /// `isSurelyPrime` gives both halves at once.
+    ///
+    /// `nil` is not "no": treat it as one deliberately, with `== true`, rather
+    /// than by reaching for `??`.
+    ///
+    /// **Never `nil` at or below `UInt64.max`.** That whole range is inside the
+    /// exhaustively verified one, so if you know your values fit a `UInt64` --
+    /// or are negative, or are anything else `Int`-sized -- the force unwrap is
+    /// safe:
+    ///
+    ///     BigInt(1000003).isPrime!                // true, and cannot trap
+    ///     BigInt(UInt64.max).isPrime!             // false
+    ///
+    /// [A014233]: https://oeis.org/A014233
+    public var isPrime: Bool? {
+        let (prime, surely) = self.isSurelyPrime
+        return surely ? prime : nil
+    }
+
+    // MARK: - walking the primes
+
+    /// The first prime greater than `self`.  Unlike the fixed-width original
+    /// this cannot run out of room, so there is no Optional to unwrap.
+    ///
+    /// The search is on `isProbablePrime`, not `isPrime`: past the deterministic
+    /// range `isPrime` is `nil`, and a walk that read that as "composite" would
+    /// step over every candidate and never return.  So above 2^64 this is the
+    /// next *probable* prime -- ask the result for its own `isSurelyPrime` if
+    /// that distinction matters.
+    public var nextPrime: Self {
+        if self < 2 { return 2 }
+        var u = self + (self & 1 == 0 ? 1 : 2)
+        while !u.isProbablePrime { u += 2 }
+        return u
+    }
+
+    /// The last prime less than `self`, or nil when there is none -- which is
+    /// what 2 and everything below it gets.  Probable above 2^64, as
+    /// `nextPrime` is.
+    public var prevPrime: Self? {
+        if self <= 2 { return nil }
+        if self == 3 { return 2 }
+        var u = self - (self & 1 == 0 ? 1 : 2)
+        while !u.isProbablePrime { u -= 2 }
+        return u
+    }
+
+    /// The primes from 2 upward, lazily and without end.
+    ///
+    ///     Array(BigInt.primes.prefix(5))      // [2, 3, 5, 7, 11]
+    public static var primes: PrimeSequence<Self> {
+        return PrimeSequence<Self>()
+    }
+}
+
+/// An endless sequence of primes, in order.  `BigInt.primes` builds one.
+public struct PrimeSequence<T: BigIntegerType> : Sequence, IteratorProtocol {
+    private var current: T? = nil
+    public init() {}
+    public mutating func next() -> T? {
+        let value = current.map { $0.nextPrime } ?? 2
+        current = value
+        return value
+    }
+}

--- a/Tests/BigNumTests/FixedWidthIntegerTests.swift
+++ b/Tests/BigNumTests/FixedWidthIntegerTests.swift
@@ -1,0 +1,228 @@
+import Testing
+@testable import BigNum
+
+///
+/// The built-in integers, now that they carry BigNum's number theory.  Every one
+/// of these operations is defined as "do it in `BigInt` and come back", so
+/// `BigInt` is the oracle: what is tested here is the round trip, not the
+/// arithmetic, which `BigIntTests` and `PrimalityTests` already pin down.
+///
+/// Hand-written expected values are deliberately rare below.  Twice while writing
+/// this I typed a modular power from memory and was wrong both times, so the
+/// constants that remain came from Python's `pow` and everything else is
+/// differential.
+///
+@Suite struct FixedWidthIntegerTests {
+
+    struct Random {
+        var state:UInt64
+        init(seed:UInt64) { state = seed }
+        mutating func next() -> UInt64 {
+            state = state &+ 0x9E3779B97F4A7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+            z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+            return z ^ (z >> 31)
+        }
+    }
+
+    // MARK: - power
+
+    @Test func powerAgainstBigInt() {
+        var rng = Random(seed: 0xC0FFEE)
+        for _ in 0 ..< 400 {
+            let base = Int(truncatingIfNeeded: rng.next()) % 1000
+            let e = Int(rng.next() % 8)
+            let wide = BigInt(base).power(e)
+            // only compare where the answer is representable -- where it is not,
+            // the fixed-width form is documented to trap, which is checked below
+            guard let want = Int(exactly: wide) else { continue }
+            #expect(base.power(e) == want, "\(base)^\(e)")
+            if base >= 0, let uwant = UInt(exactly: wide) {
+                #expect(UInt(base).power(e) == uwant, "unsigned \(base)^\(e)")
+            }
+            if let small = Int8(exactly: wide), let b8 = Int8(exactly: base) {
+                #expect(b8.power(e) == small, "Int8 \(base)^\(e)")
+            }
+        }
+        // the edges of what each width can hold
+        #expect(Int(2).power(62) == 4611686018427387904)
+        #expect(UInt(2).power(63) == 9223372036854775808)
+        #expect(Int8(11).power(2) == 121)
+        #expect(UInt8(15).power(2) == 225)
+        #expect(Int(-2).power(3) == -8 && Int(-2).power(4) == 16)
+        #expect(Int(5).power(0) == 1 && Int(5).power(1) == 5)
+        #expect(Int(5).power(-2) == 0, "no integral reciprocal, as for BigInt")
+        #expect(Int(1).power(-9) == 1 && Int(-1).power(-9) == -1)
+    }
+
+    /// The modular form is the one that cannot overflow, since the answer is
+    /// bounded by a modulus that is a `Self` already.  It is therefore also the
+    /// one worth checking at full width.
+    @Test func powerModNeverOverflowsAndMatchesBigInt() {
+        var rng = Random(seed: 0xBEEF)
+        for _ in 0 ..< 500 {
+            let base = Int(truncatingIfNeeded: rng.next())
+            let m = Int(truncatingIfNeeded: rng.next())
+            if m == 0 { continue }
+            let e = Int(rng.next() % 64)
+            let want = BigInt(base).power(e, mod: BigInt(m))
+            #expect(base.power(e, mod: m) == Int(want), "\(base)^\(e) mod \(m)")
+        }
+        // narrow types, where the naive `a * b % m` would overflow immediately
+        for _ in 0 ..< 300 {
+            let base = UInt8(truncatingIfNeeded: rng.next())
+            let m = UInt8(truncatingIfNeeded: rng.next())
+            if m == 0 { continue }
+            let e = Int(rng.next() % 200)
+            let want = BigInt(base).power(e, mod: BigInt(m))
+            #expect(base.power(e, mod: m) == UInt8(want), "UInt8 \(base)^\(e) mod \(m)")
+        }
+        // at the very top of the range, where a product is two words wide
+        #expect(UInt64.max.power(3, mod: UInt64.max - 2) == 8)
+        #expect((Int.max - 1).power(Int.max - 2, mod: Int.max)
+                  == Int(BigInt(Int.max - 1).power(BigInt(Int.max - 2), mod: BigInt(Int.max))))
+        // Python's pow, for the values the documentation quotes
+        #expect(Int(2).power(1024, mod: 1_000_000_007) == 812734592)
+        #expect(Int(2).power(10, mod: 1000) == 24)
+        #expect(UInt8(200).power(200, mod: 251) == 1)
+        // and the conventions carry over from BigInt unchanged
+        #expect(Int(-2).power(3, mod: 5) == 2, "the sign of the modulus")
+        #expect(Int(2).power(3, mod: -5) == -2, "a negative modulus")
+        #expect(Int(2).power(-1, mod: 5) == 3, "a negative exponent is the inverse")
+        #expect(Int(5).power(3, mod: 1) == 0)
+        // the exponent is generic, so all of these have to compile and agree
+        #expect(Int(3).power(20, mod: 1_000_003) == 773943)
+        #expect(Int(3).power(Int(20), mod: 1_000_003) == 773943)
+        #expect(Int(3).power(UInt8(20), mod: 1_000_003) == 773943)
+        #expect(Int(3).power(BigInt(20), mod: 1_000_003) == 773943)
+    }
+
+    // MARK: - roots and divisors
+
+    /// `squareRoot()` and `greatestCommonDivisor(with:)` reached the *signed*
+    /// built-ins long ago through `RationalElement`; only the unsigned ones are
+    /// new.  Both are checked here, since the point is that every built-in width
+    /// now has them and gives the same answer.
+    @Test func rootsAndDivisorsAgainstBigInt() {
+        var rng = Random(seed: 0x5EED)
+        for _ in 0 ..< 500 {
+            let a = Int(truncatingIfNeeded: rng.next())
+            let b = Int(truncatingIfNeeded: rng.next())
+            let ua = UInt(bitPattern: a), ub = UInt(bitPattern: b)
+            #expect(ua.squareRoot() == UInt(BigInt(ua).squareRoot()), "√\(ua)")
+            if a >= 0 { #expect(a.squareRoot() == Int(BigInt(a).squareRoot()), "√\(a)") }
+            #expect(ua.greatestCommonDivisor(with: ub)
+                      == UInt(BigInt(ua).greatestCommonDivisor(with: BigInt(ub))),
+                    "gcd(\(ua), \(ub))")
+            // the signed one traps only for gcd(Int.min, Int.min), avoided here
+            if a != Int.min || b != Int.min {
+                #expect(a.greatestCommonDivisor(with: b)
+                          == Int(BigInt(a).greatestCommonDivisor(with: BigInt(b))),
+                        "gcd(\(a), \(b))")
+            }
+        }
+        #expect(UInt8(255).squareRoot() == 15 && UInt8(256 - 1).squareRoot() == 15)
+        #expect(UInt(4611686018427387904).squareRoot() == 2147483648)
+        #expect(UInt(0).squareRoot() == 0 && UInt(1).squareRoot() == 1)
+        #expect(UInt(1071).greatestCommonDivisor(with: 462) == 21)
+        #expect(UInt8(48).greatestCommonDivisor(with: 18) == 6)
+        #expect(UInt(0).greatestCommonDivisor(with: 5) == 5)
+        #expect(Int(-12).greatestCommonDivisor(with: 18) == 6, "pre-existing, still right")
+    }
+
+    // MARK: - primality
+
+    @Test func primalityMatchesBigInt() {
+        for n in 0 ..< 2000 {
+            let wide = BigInt(n)
+            #expect(n.isPrime == wide.isPrime, "isPrime of \(n)")
+            #expect(n.isProbablePrime == wide.isProbablePrime, "isProbablePrime of \(n)")
+            #expect(n.isSurelyPrime == wide.isSurelyPrime, "isSurelyPrime of \(n)")
+            #expect(UInt(n).isPrime == wide.isPrime, "unsigned isPrime of \(n)")
+            #expect((-n).isPrime == BigInt(-n).isPrime, "isPrime of -\(n)")
+            if n >= 3 && n & 1 == 1 {
+                #expect(n.isLucasProbablePrime == wide.isLucasProbablePrime, "Lucas of \(n)")
+                #expect(n.millerRabinTest(base: 2) == wide.millerRabinTest(base: 2), "MR of \(n)")
+            }
+            #expect(n.isMersennePrime == wide.isMersennePrime, "isMersennePrime of \(n)")
+            for a in [-7, -1, 0, 1, 2, 3, 5] {
+                #expect(n.jacobiSymbol(a) == wide.jacobiSymbol(a), "jacobi(\(a)/\(n))")
+            }
+        }
+        // the narrow widths, exhaustively -- every value a UInt8 can hold
+        for n in UInt8.min ... UInt8.max {
+            #expect(n.isPrime == BigInt(n).isPrime, "UInt8 \(n)")
+        }
+        for n in Int8.min ... Int8.max {
+            #expect(n.isPrime == BigInt(n).isPrime, "Int8 \(n)")
+        }
+        // and the top of the 64-bit range
+        #expect(UInt64.max.isPrime! == false)
+        #expect(Int.max.isPrime! == false)
+        #expect(Int.min.isPrime! == false)
+        #expect(UInt64(18446744073709551557).isPrime! == true, "the last prime below 2^64")
+        #expect(Int(9223372036854775783).isPrime! == true, "the last prime below 2^63")
+    }
+
+    /// The guarantee that makes `isPrime!` safe on the built-ins: no type of 64
+    /// bits or fewer can hold a value outside the exhaustively verified range.
+    /// The force unwraps *are* the assertions -- they trap if that ever breaks.
+    @Test func isPrimeIsNeverNilForTheBuiltins() {
+        for n in 0 ..< 1000 {
+            #expect(n.isPrime != nil)
+            #expect(UInt(n).isPrime != nil)
+            #expect((-n).isPrime! == false)
+        }
+        var primesNearTheTop = 0
+        for offset in 0 ... 80 {
+            let n = UInt64.max - UInt64(offset)
+            #expect(n.isPrime != nil, "\(n)")
+            if n.isPrime == true { primesNearTheTop += 1 }
+            #expect((Int.max - offset).isPrime != nil, "\(Int.max - offset)")
+            #expect((Int.min + offset).isPrime! == false, "negatives are settled")
+        }
+        #expect(primesNearTheTop > 0, "the window must hold a prime to be testing anything")
+        for n in UInt8.min ... UInt8.max { #expect(n.isPrime != nil, "UInt8 \(n)") }
+        for n in Int16.min ... Int16.min + 200 { #expect(n.isPrime != nil, "Int16 \(n)") }
+    }
+
+    @Test func walkingThePrimes() {
+        for n in 0 ..< 500 {
+            #expect(n.nextPrime == Int(BigInt(n).nextPrime), "nextPrime of \(n)")
+            #expect(n.prevPrime.map { BigInt($0) } == BigInt(n).prevPrime, "prevPrime of \(n)")
+            #expect(UInt(n).nextPrime == UInt(BigInt(n).nextPrime), "unsigned nextPrime of \(n)")
+        }
+        #expect(Int(1000).nextPrime == 1009 && Int(1000).prevPrime == 997)
+        #expect(Int(2).prevPrime == nil && UInt(2).prevPrime == nil && Int(-5).prevPrime == nil)
+        #expect(Int(0).nextPrime == 2 && Int(-5).nextPrime == 2 && UInt(0).nextPrime == 2)
+        #expect(UInt8(200).nextPrime == 211)
+        #expect(UInt8(255).prevPrime == 251)
+        // the sequence, which walks by nextPrime
+        #expect(Array(Int.primes.prefix(10)) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29])
+        #expect(Array(UInt8.primes.prefix(5)) == [2, 3, 5, 7, 11])
+        #expect(Array(Int.primes.prefix(200)) == BigInt.primes.prefix(200).map { Int($0) })
+        #expect(Int.primes.first(where: { $0 > 1000 }) == 1009)
+    }
+
+    /// A 128-bit type is the one built-in that can hold a value past
+    /// `UInt64.max`, which is the only place `isPrime` can be `nil` here.
+    @Test func oneHundredTwentyEightBitIsTheExceptionToTheGuarantee() throws {
+        guard #available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *) else { return }
+        #expect(Int128(1000003).isPrime == true, "small values are settled as ever")
+        #expect(Int128(1000001).isPrime == false)
+        #expect(Int128(-7).isPrime == false)
+        #expect(Int128(UInt64.max).isPrime == false, "at the guarantee's edge")
+        // a prime above 2^64 is where a 128-bit type stops being able to force
+        // unwrap: BPSW says prime, and nothing here proves it
+        let past64 = Int128(BigInt(1) << 100)
+        #expect(past64.nextPrime.isPrime == nil, "above 2^64, unproven")
+        #expect(past64.nextPrime.isProbablePrime, "though BPSW still says prime")
+        #expect((past64 + 1).isPrime == false, "a composite is settled at any size")
+        // and it agrees with BigInt throughout
+        #expect(Int128(1) << 100 == Int128(BigInt(1) << 100))
+        #expect(past64.nextPrime == Int128(BigInt(past64).nextPrime))
+        #expect(Int128(3).power(40, mod: 1_000_003)
+                  == Int128(BigInt(3).power(40, mod: BigInt(1_000_003))))
+    }
+}

--- a/Tests/BigNumTests/PrimalityTests.swift
+++ b/Tests/BigNumTests/PrimalityTests.swift
@@ -1,0 +1,322 @@
+import Testing
+@testable import BigNum
+
+///
+/// The primality tests, against oracles that share nothing with them: a sieve of
+/// Eratosthenes for the small numbers, published pseudoprime lists for the cases
+/// built to defeat exactly these algorithms, and the known Mersenne exponents.
+///
+@Suite struct PrimalityTests {
+
+    /// Plain Eratosthenes -- no modular exponentiation, no Lucas sequence, no
+    /// idea in common with what it checks.
+    static let limit = 20_000
+    static let sieve:[Bool] = {
+        var s = [Bool](repeating: true, count: limit)
+        s[0] = false ; s[1] = false
+        var i = 2
+        while i * i < limit {
+            if s[i] { var j = i * i ; while j < limit { s[j] = false ; j += i } }
+            i += 1
+        }
+        return s
+    }()
+    static let primes:[Int] = (0 ..< limit).filter { sieve[$0] }
+
+    @Test func againstTheSieve() {
+        var wrong = 0
+        for n in 0 ..< Self.limit {
+            // every n here is far below 2^64, so a nil would itself be a bug --
+            // comparing the Optional to a Bool catches that as well as a wrong answer
+            if BigInt(n).isPrime  != Self.sieve[n] { wrong += 1 }
+            if BigUInt(n).isPrime != Self.sieve[n] { wrong += 1 }
+        }
+        #expect(wrong == 0, "\(wrong) disagreements with the sieve below \(Self.limit)")
+    }
+
+    @Test func negativesAreNeverPrime() {
+        for n in 1 ... 100 { #expect(BigInt(-n).isPrime == false, "-\(n) called prime") }
+        #expect(BigInt(0).isPrime == false && BigInt(1).isPrime == false)
+        #expect(BigUInt(0).isPrime == false && BigUInt(1).isPrime == false)
+        #expect(BigInt(2).isPrime == true && BigInt(3).isPrime == true)
+    }
+
+    /// Strong pseudoprimes to base 2: composites that Miller-Rabin on base 2
+    /// cannot see through, so only the Lucas half of BPSW rejects them.  Both
+    /// halves are load-bearing and this is the list that proves it.
+    @Test func strongPseudoprimesToBase2() {
+        let spsp2 = [2047, 3277, 4033, 4681, 8321, 15841, 29341, 42799, 49141,
+                     52633, 65281, 74665, 80581, 85489, 88357, 90751,
+                     1373653, 25326001, 3215031751]
+        for n in spsp2 {
+            #expect(BigInt(n).millerRabinTest(base: 2),
+                    "\(n) is a strong pseudoprime to base 2 and should pass that test")
+            #expect(BigInt(n).isPrime == false, "\(n) is composite but isPrime said true")
+        }
+    }
+
+    /// Carmichael numbers, which pass Fermat's test for every coprime base.
+    @Test func carmichaelNumbers() {
+        for n in [561, 1105, 1729, 2465, 2821, 6601, 8911, 10585, 15841, 29341,
+                  41041, 46657, 52633, 62745, 63973, 75361] {
+            #expect(BigInt(n).isPrime == false, "Carmichael \(n) called prime")
+            #expect(BigInt(n).isSurelyPrime == (false, surely: true),
+                    "a composite is always certain")
+        }
+    }
+
+    /// Every entry of A014233 is composite by construction -- that is what makes
+    /// it the boundary of what a set of Miller-Rabin bases can prove.
+    @Test func a014233EntriesAreComposite() {
+        for (i, entry) in BigInt.A014233.enumerated() {
+            #expect(entry.isPrime == false, "A014233[\(i)] = \(entry) called prime")
+            #expect(entry.isSurelyPrime == (false, surely: true), "A014233[\(i)]")
+        }
+        #expect(BigInt.A014233.count == BigInt._A014233Bases.count,
+                "the table and its bases must stay in step")
+        // it is sorted, which the isSurelyPrime loop relies on
+        for i in 1 ..< BigInt.A014233.count {
+            #expect(BigInt.A014233[i - 1] <= BigInt.A014233[i], "A014233 out of order at \(i)")
+        }
+    }
+
+    /// Jacobi symbols against the recurrence written out directly in `Int`.
+    func jacobiOracle(_ a:Int, _ n:Int) -> Int {
+        if n <= 0 || n % 2 == 0 { return 0 }
+        var (a, n, result) = (((a % n) + n) % n, n, 1)
+        while a != 0 {
+            while a % 2 == 0 {
+                a /= 2
+                if n % 8 == 3 || n % 8 == 5 { result = -result }
+            }
+            swap(&a, &n)
+            if a % 4 == 3 && n % 4 == 3 { result = -result }
+            a %= n
+        }
+        return n == 1 ? result : 0
+    }
+
+    @Test func jacobiSymbolAgainstOracle() {
+        for n in [1, 3, 5, 7, 9, 15, 21, 45, 101, 1001, 9999, 104729] {
+            for a in -60 ... 60 {
+                #expect(BigInt(n).jacobiSymbol(a) == jacobiOracle(a, n),
+                        "jacobi(\(a)/\(n))")
+                #expect(BigUInt(n).jacobiSymbol(a) == jacobiOracle(a, n),
+                        "unsigned jacobi(\(a)/\(n))")
+            }
+        }
+        // an even or non-positive modulus has no symbol
+        for n in [0, 2, 4, 8, 100] { #expect(BigInt(n).jacobiSymbol(3) == 0, "jacobi(3/\(n))") }
+        for n in [-1, -3, -7] { #expect(BigInt(n).jacobiSymbol(3) == 0, "jacobi(3/\(n))") }
+        // (a/1) is 1 for every a, including 0
+        #expect(BigInt(1).jacobiSymbol(0) == 1 && BigInt(3).jacobiSymbol(0) == 0)
+    }
+
+    /// The Mersenne exponents are published, and Lucas-Lehmer is exact, so this
+    /// is a straight lookup rather than a probable answer.
+    @Test func lucasLehmerAgainstTheKnownMersennePrimes() {
+        let primeExponents = [2, 3, 5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521, 607]
+        for p in primeExponents {
+            #expect((BigInt(1) << p - 1).isMersennePrime == true, "M\(p) is a Mersenne prime")
+            #expect((BigUInt(1) << p - 1).isMersennePrime == true, "unsigned M\(p)")
+            #expect((BigInt(1) << p - 1).isSurelyPrime == (true, surely: true),
+                    "Lucas-Lehmer settles M\(p) outright")
+        }
+        // prime exponents whose Mersenne number is not prime
+        for p in [11, 23, 29, 37, 41, 43, 47, 53, 59, 67, 71, 73, 79, 83, 97, 101, 103] {
+            #expect((BigInt(1) << p - 1).isMersennePrime == false, "M\(p) is composite")
+        }
+        // a composite exponent always gives a composite Mersenne number
+        for p in [4, 6, 8, 9, 10, 12, 15, 21, 25, 33, 49] {
+            #expect((BigInt(1) << p - 1).isMersennePrime == false,
+                    "M\(p) has a composite exponent")
+        }
+        // and anything that is not 2^p - 1 has no answer at all
+        for n in [0, 1, 2, 4, 5, 6, 8, 9, 10, 11, 12, 13, 100, 1000, 1 << 20] {
+            #expect(BigInt(n).isMersennePrime == nil, "\(n) is not a Mersenne number")
+        }
+        #expect(BigInt(-7).isMersennePrime == nil, "a negative is not a Mersenne number")
+    }
+
+    /// Miller-Rabin proves compositeness but never primality, so the only thing
+    /// to pin per base is that it agrees with the sieve when it says "composite"
+    /// and never contradicts a prime.
+    @Test func millerRabinNeverRejectsAPrime() {
+        for base in [BigInt(2), 3, 5, 7, 11, 13] {
+            for n in Self.primes.prefix(400) where BigInt(n) > base {
+                #expect(BigInt(n).millerRabinTest(base: base),
+                        "\(n) is prime but base \(base) called it composite")
+            }
+        }
+        #expect(!BigInt(1).millerRabinTest(base: 2))
+        #expect(!BigInt(0).millerRabinTest(base: 2))
+        #expect(BigInt(2).millerRabinTest(base: 2), "2 is even and prime")
+        #expect(!BigInt(4).millerRabinTest(base: 2), "an even composite")
+    }
+
+    @Test func walkingThePrimes() {
+        // nextPrime lands on the sieve's primes, in order
+        var walked:[Int] = []
+        var cursor = BigInt(0)
+        while walked.count < 500 { cursor = cursor.nextPrime ; walked.append(Int(cursor)) }
+        #expect(walked == Array(Self.primes.prefix(500)), "the nextPrime walk")
+        // and so does the sequence
+        #expect(BigInt.primes.prefix(500).map { Int($0) } == walked, "BigInt.primes")
+        #expect(Array(BigUInt.primes.prefix(10)) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29])
+        // both directions, against the sieve
+        // every n here needs a prime on each side of it *within* the sieve, so
+        // stay clear of its top end
+        for n in [2, 3, 4, 5, 6, 100, 1000, 7919, 7920, 19000] {
+            #expect(Int(BigInt(n).nextPrime) == Self.primes.first(where: { $0 > n })!,
+                    "nextPrime of \(n)")
+            let want = Self.primes.last(where: { $0 < n })
+            #expect(BigInt(n).prevPrime.map { Int($0) } == want, "prevPrime of \(n)")
+        }
+        // the edges below 2, where there is no previous prime
+        #expect(BigInt(0).prevPrime == nil && BigInt(1).prevPrime == nil)
+        #expect(BigInt(2).prevPrime == nil && BigInt(-5).prevPrime == nil)
+        #expect(BigUInt(2).prevPrime == nil && BigUInt(0).prevPrime == nil)
+        #expect(BigInt(3).prevPrime == 2)
+        #expect(BigInt(0).nextPrime == 2 && BigInt(-5).nextPrime == 2 && BigUInt(0).nextPrime == 2)
+        // arbitrary precision means nextPrime can never run out of room, which is
+        // why it is not an Optional -- there is nothing here to correspond to a
+        // fixed-width type's overflow
+        #expect((BigInt(1) << 64).nextPrime == BigInt("18446744073709551629")!)
+    }
+
+    /// Above A014233's last entry a prime is only probable; below it, and for any
+    /// Mersenne number, the answer is certain.
+    @Test func certaintyBoundary() {
+        let beyond = BigInt(1) << 200
+        #expect(beyond.isSurelyPrime == (false, surely: true), "a composite is always certain")
+        // the first prime past 2^200, from the other side: BPSW says prime, but
+        // it is above every deterministic bound this package has
+        let p200 = (BigInt(1) << 200).nextPrime
+        #expect(p200.isProbablePrime)
+        #expect(p200.isPrime == nil, "BPSW says prime, but nothing here proves it")
+        #expect(p200.isSurelyPrime == (true, surely: false),
+                "past the table, a prime is only probable")
+        // small primes stay certain
+        for n in [2, 3, 5, 7, 97, 65537] {
+            #expect(BigInt(n).isSurelyPrime == (true, surely: true), "\(n)")
+        }
+        // BPSW is exhaustively verified below 2^64, so that whole range is certain
+        #expect(BigInt("18446744073709551557")!.isSurelyPrime == (true, surely: true),
+                "the largest prime below 2^64 is certainly prime")
+        #expect(BigInt(UInt64.max).isSurelyPrime == (false, surely: true))
+    }
+
+    /// `isPrime` has three answers, and the line between `true` and `nil` is
+    /// exactly where a proof runs out.
+    @Test func isPrimeWithholdsWhatItCannotProve() {
+        #expect(BigInt(1000003).isPrime == true, "small primes are provable")
+        #expect(BigInt(1000001).isPrime == false, "101 * 9901")
+        // it is `isSurelyPrime` gated on its own second half, and nothing else
+        for n in 0 ..< 300 {
+            let (prime, surely) = BigInt(n).isSurelyPrime
+            #expect(BigInt(n).isPrime == (surely ? prime : nil), "isPrime of \(n)")
+        }
+        // A composite is provable at any size: a witness is a proof.
+        #expect((BigInt(1) << 1000).isPrime == false, "a huge even number")
+        let m127 = BigInt(1) << 127 - 1
+        let m89  = BigInt(1) << 89 - 1
+        #expect((m127 * m89).isPrime == false, "a 216-bit product of two primes")
+        // A Mersenne prime is provable at any size, because Lucas-Lehmer is exact
+        #expect((BigInt(1) << 521 - 1).isPrime == true, "M521, far above 2^64")
+        #expect((BigInt(1) << 523 - 1).isPrime == false, "M523")
+        // The boundary itself: A014233's last entry is where thirteen
+        // Miller-Rabin bases stop proving things.
+        let table = BigInt.A014233
+        let bound = table[table.count - 1]
+        let below = bound.prevPrime!
+        let above = bound.nextPrime
+        #expect(below < bound && bound < above, "straddling the bound")
+        #expect(below.isPrime == true, "\(below) is below the bound and provable")
+        #expect(above.isPrime == nil, "\(above) is above it and is not")
+        #expect(above.isProbablePrime, "though BPSW still says prime")
+        #expect(below.isProbablePrime, "and agrees below the bound")
+        // 2^64 is the other boundary, and it is covered by the table rather than
+        // being the end of certainty
+        #expect(BigInt("18446744073709551557")!.isPrime == true, "the last prime below 2^64")
+        #expect((BigInt(1) << 64).nextPrime.isPrime == true, "just above 2^64, still provable")
+        // The rename this change forced: `nextPrime` searches on
+        // `isProbablePrime`, so it must still terminate where `isPrime` is nil.
+        // Reading nil as "composite" would walk past every candidate forever.
+        let floor200 = BigInt(1) << 200
+        let high = floor200.nextPrime
+        #expect(high > floor200, "nextPrime terminated above the deterministic range")
+        #expect(high.isPrime == nil, "and its answer is withheld")
+        #expect(high.isProbablePrime, "though BPSW still says prime")
+    }
+
+    /// The documented guarantee that makes `isPrime!` safe: at or below
+    /// `UInt64.max` the answer is never withheld.  Every force unwrap here is the
+    /// assertion -- it traps rather than fails if the guarantee ever breaks.
+    @Test func isPrimeIsNeverNilThroughUInt64Max() {
+        for n in 0 ..< 3000 {
+            #expect(BigInt(n).isPrime != nil, "\(n)")
+            #expect(BigUInt(n).isPrime != nil, "unsigned \(n)")
+            #expect(BigInt(-n).isPrime! == false, "negatives are settled too: -\(n)")
+        }
+        // The boundary itself, and the values just inside it.  The window has to
+        // reach 58 below the ceiling to contain a prime at all -- a narrower one
+        // would be all composites, and a composite is settled by a witness no
+        // matter what the certainty rules say, so it could not detect a prime
+        // being withheld here.
+        let ceiling = BigInt(UInt64.max)
+        var primesFound = 0
+        for offset in 0 ... 80 {
+            let n = ceiling - BigInt(offset)
+            #expect(n.isPrime != nil, "\(n) is at or below UInt64.max")
+            #expect(BigUInt(n).isPrime != nil, "unsigned \(n)")
+            if n.isPrime == true { primesFound += 1 }
+        }
+        #expect(primesFound > 0, "the window below the ceiling must contain a prime to be a test")
+        #expect(ceiling.isPrime! == false, "UInt64.max == 3 * 5 * 17 * 257 * 641 * 65537 * 6700417")
+        #expect(BigInt("18446744073709551557")!.isPrime! == true, "the last prime below 2^64")
+        #expect(BigInt(Int.max).isPrime! == false, "Int.max == 7^2 * 73 * 127 * 337 * 92737 * 649657")
+        #expect(BigInt(Int.min).isPrime! == false, "and anything negative")
+        // powers of two and Mersenne-shaped values inside the range, which take
+        // different routes through isSurelyPrime
+        #expect((BigInt(1) << 1).isPrime! == true, "2^1 is 2, the one even prime")
+        for p in 2 ... 63 {
+            #expect((BigInt(1) << p).isPrime! == false, "2^\(p) is even and above 2")
+            #expect((BigInt(1) << p - 1).isPrime != nil, "M\(p) is inside the range")
+        }
+        // just above the ceiling nothing is promised, but a composite is still settled
+        #expect((ceiling + 1).isPrime! == false, "2^64 is even, so still provable")
+    }
+
+    /// A `BigInt` and a `BigUInt` of the same value must never disagree.
+    @Test func signedAndUnsignedAgree() {
+        for n in 0 ..< 1000 {
+            #expect(BigInt(n).isPrime == BigUInt(n).isPrime, "isPrime of \(n)")
+            #expect(BigInt(n).isSurelyPrime == BigUInt(n).isSurelyPrime, "isSurelyPrime of \(n)")
+            #expect(BigInt(n).isLucasProbablePrime == BigUInt(n).isLucasProbablePrime,
+                    "isLucasProbablePrime of \(n)")
+        }
+    }
+
+    /// Large values, where the sieve cannot follow.  These are pinned by
+    /// construction instead: a product of two primes is composite, and the primes
+    /// themselves come out of `nextPrime` above a known power of two.
+    @Test func largeValues() {
+        let a = (BigInt(1) << 128).nextPrime
+        let b = (BigInt(1) << 129).nextPrime
+        // 128-bit primes are past every deterministic bound, so isPrime declines
+        // to call them prime -- but their compositeness is still provable
+        #expect(a.isPrime == nil && b.isPrime == nil, "unproven above the bound")
+        #expect(a.isProbablePrime && b.isProbablePrime, "nextPrime returned a composite")
+        #expect((a * b).isPrime == false, "the product of two primes is composite")
+        #expect((a * b).isSurelyPrime == (false, surely: true))
+        #expect((a * a).isPrime == false, "a square is composite")
+        #expect(!(a * a).isLucasProbablePrime, "a perfect square fails the Lucas test outright")
+        // a 256-bit prime.  Deliberately not wider: every candidate `nextPrime`
+        // steps over costs a full BPSW test, and in a debug build a 512-bit
+        // search alone ran longer than the rest of the suite put together.
+        let big = (BigInt(1) << 256).nextPrime
+        #expect(big.isProbablePrime)
+        #expect(big.isPrime == nil, "a 256-bit prime is not provable here")
+        #expect((big * 2).isPrime == false, "an even number above 2")
+    }
+}

--- a/macOS.playground/Pages/BigInt.xcplaygroundpage/Contents.swift
+++ b/macOS.playground/Pages/BigInt.xcplaygroundpage/Contents.swift
@@ -89,6 +89,67 @@ BigInt(3).power(-3, mod: 7)         // 6
 BigInt(3).power(m127 - 1, mod: m127)            // 1
 BigInt(3).power(BigInt(1) << 100, mod: 1000000007)
 
+//: ## Primality.  `isPrime` is a Bool? -- nil means "not proven", never "no"
+BigInt(1000003).isPrime                         // true
+BigInt(1000001).isPrime                         // false, 101 * 9901
+BigInt(561).isPrime                             // false -- a Carmichael number
+m127.isPrime                                    // true, since Lucas-Lehmer settles it
+(BigInt(1) << 300).nextPrime.isPrime            // nil -- probably prime, unproven
+
+//: At or below UInt64.max it is never nil -- that range is exhaustively
+//: verified -- so for numbers that size the force unwrap cannot trap
+BigInt(1000003).isPrime!                        // true
+BigInt(UInt64.max).isPrime!                     // false
+BigInt(-7).isPrime!                             // false
+
+//: The probable answer is still there under its own name, and `isSurelyPrime`
+//: hands back both halves.  A composite is provable at any size; a prime needs
+//: to be below 2^64, below A014233's last entry, or a Mersenne number.
+(BigInt(1) << 300).nextPrime.isProbablePrime    // true, where isPrime said nil
+BigInt(65537).isSurelyPrime                     // (true, surely: true)
+BigInt(561).isSurelyPrime                       // (false, surely: true)
+(BigInt(1) << 300).nextPrime.isSurelyPrime      // (true, surely: false)
+
+//: Both halves of BPSW pull their weight: 2047 == 23 * 89 slips past Miller-Rabin
+//: on base 2, and only the Lucas test catches it
+BigInt(2047).millerRabinTest(base: 2)           // true
+BigInt(2047).isLucasProbablePrime               // false
+BigInt(7).jacobiSymbol(3)                       // -1
+
+//: A Mersenne number has an exact test -- and `nil` means "not 2^p - 1 at all",
+//: which is not the same answer as `false`
+m127.isMersennePrime                            // true
+(BigInt(1) << 523 - 1).isMersennePrime          // false
+BigInt(100).isMersennePrime                     // nil
+
+//: Walking the primes.  nextPrime needs no Optional: there is no ceiling here.
+BigInt(1000).nextPrime                          // 1009
+(BigInt(1) << 64).nextPrime                     // 18446744073709551629
+(BigInt(1) << 64).prevPrime                     // 18446744073709551557
+BigInt(2).prevPrime                             // nil
+Array(BigInt.primes.prefix(10))
+
+/*:
+ ## All of the above, on the built-in integers
+
+ `Int`, `UInt`, `Int8` ... `UInt64` and `Int128` get every one of these.  Each
+ widens to `BigInt`, works there, and comes back -- so an answer that does not
+ fit traps, just as `*` would.
+ */
+Int(2).power(10)                                // 1024
+1000003.isPrime!                                // true -- never nil at this width
+UInt8(200).nextPrime                            // 211
+Int(1071).greatestCommonDivisor(with: 462)      // 21
+UInt(4611686018427387904).squareRoot()          // 2147483648
+Array(Int.primes.prefix(5))                     // [2, 3, 5, 7, 11]
+
+//: The modular form cannot overflow -- the answer is bounded by the modulus,
+//: which is an Int already.  `power(_:) % m` could not manage this.
+Int(2).power(1024, mod: 1_000_000_007)          // 812734592
+UInt8(200).power(200, mod: 251)                 // 1, where 200*200 overflows a UInt8
+//: Int(2).power(1024)                          // would trap: an Int has no such number
+//: Int8(127).nextPrime                         // would trap: 131 does not fit
+
 //: ## Strings and conversions
 BigInt(255).toString(radix:16)
 BigInt(255).toString(radix:16, uppercase:true)


### PR DESCRIPTION
Two additions, the second following from the first.

## Primality.swift

The primality half of [swift2-pons]'s `xtra_prime.swift`, ported to `BigIntegerType` so `BigInt` and `BigUInt` share one implementation: `millerRabinTest(base:)`, `jacobiSymbol(_:)`, `isLucasProbablePrime`, `isMersennePrime`, `isPrime`/`isProbablePrime`/`isSurelyPrime`, `nextPrime`/`prevPrime`, and `primes`. The factorization half of that file is deliberately not here.

```swift
BigInt(1000003).isPrime                  // true
BigInt(561).isPrime                      // false -- a Carmichael number is not fooling this
(BigInt(1) << 521 - 1).isPrime           // true  -- Lucas-Lehmer settles it exactly
(BigInt(1) << 300).nextPrime.isPrime     // nil   -- probably prime, unproven
```

`millerRabinTest(base:)` is the first real caller of the wide exponent added in #15 — the exponent there is `(self - 1)` shifted past its trailing zeros.

### Three departures from the original

**`isPrime` is a `Bool?`.** The original returns a plain `Bool`, which for a number past every deterministic bound reports "BPSW found no witness" as though it were a fact. Here that case is `nil`. A `false` is always available — a witness to compositeness is a proof at any size — and a `true` needs the value below 2^64, below A014233's last entry, or a Mersenne number. Below `UInt64.max` it is never `nil`, so `isPrime!` is safe there and the docs say so. The raw BPSW result is `isProbablePrime`; both halves together are `isSurelyPrime`.

**`nextPrime` returns a value, not an Optional** — arbitrary precision has no ceiling to fall off. It searches on `isProbablePrime`, *not* `isPrime`: a walk that read `nil` as "composite" would step over every candidate and hang. I verified that it does hang, rather than assuming it.

**`isMersennePrime` recovers `p` from the value** (`self + 1` being a power of two) rather than from a word size, and answers M2 == 3 directly — the original's zero-iteration recurrence leaves `s == 4` and reports `false`.

## FixedWidthInteger.swift

All of the above, plus `power(_:)` and `power(_:mod:)`, on `Int`, `UInt`, `Int8` … `UInt64` and `Int128`:

```swift
Int(2).power(10)                        // 1024
1000003.isPrime!                        // true
UInt8(200).nextPrime                    // 211
Int(2).power(1024, mod: 1_000_000_007)  // 812734592 -- cannot overflow
Int(2).power(1024)                      // traps: an Int has no such number
```

Every member is `Self(BigInt(self).theOperation())`, trapping when the answer does not fit, as `*` does. Delegating is not laziness: a native modular multiply needs an overflow-avoiding variant per width, and a call from a context generic over `FixedWidthInteger` would statically pick whichever one the compiler saw, so correctness would depend on the call site. `BigInt` has one implementation and leaves one question — does the answer fit. [BigInt.md](BigInt.md#on-the-built-in-integers-too) tables which operations can trap and which cannot.

### Two collisions worth a reviewer's attention

`squareRoot()` and `greatestCommonDivisor(with:)` **already reached the signed built-ins** through `RationalElement` in Rational.swift, by this same widen-and-return trick — `Int(10).squareRoot()` predates this branch. So the new ones are `where Self : UnsignedInteger`, filling the gap `RationalElement` leaves by being a `SignedInteger`. Unconstrained, `Int` goes ambiguous and Rational.swift stops compiling.

`power(_:mod:)` here is **one generic overload** rather than the `Int`/`Self` pair `BigIntegerType` has, because when `Self` is `Int` those two are the same signature and every call site is ambiguous. `BigIntegerType`'s pair is left alone — for `BigInt` the signatures are distinct — and call sites read identically either way.

## Testing

Oracles that share nothing with the implementations:

- a **sieve of Eratosthenes** for the small numbers, both types
- the published **strong pseudoprimes to base 2** and **Carmichael numbers** — the numbers built to defeat exactly these algorithms, and what proves both halves of BPSW load-bearing
- **Python** — 21 primes and 21 composites from 64 to 1024 bits, plus 165 Jacobi symbols
- the **known Mersenne exponents**, where Lucas-Lehmer is exact

The fixed-width tests are differential against `BigInt` rather than against constants. Five expected values I wrote from memory this session were wrong and the library was right every time, so the surviving literals come from Python's `pow` and the test file records why.

Ten mutations across the two files, all caught — two only via a trap rather than a failed expectation, which is worth knowing if you extend these tests. Three initially survived and were run down rather than ignored: narrowing the 2^64 certainty rule changes nothing because A014233 independently covers that range; no composite exponent in 4…600 makes the Lucas-Lehmer recurrence return 0; and dropping the perfect-square guard trips a precondition on 9. Two guards inside that recurrence are unreached for every prime exponent up to 1300 and are commented as insurance rather than repairs.

### One deviation made and then removed

I first ended the Lucas test at `u == 0 || v == 0`, reasoning that for a prime exactly one of U_h and V_h vanishes depending on (Q/n). Measuring said otherwise: across every odd number below 300000, `u` vanishes for all 25996 primes and 132 composites, and `v` for neither, ever. The clause was dead code that could only have admitted extra composites had it ever fired. Reverted to the original's `u == 0`.

67 tests pass, suite time 9 s. All documented examples verified by execution; all six playground pages recompile and run.

[swift2-pons]: https://github.com/dankogai/swift2-pons

🤖 Generated with [Claude Code](https://claude.com/claude-code)