### PR TITLE
Add `**` in a module of its own, so it stays off unless imported

### DIFF
--- a/BigInt.md
+++ b/BigInt.md
@@ -162,6 +162,9 @@ BigInt(1071).greatestCommonDivisor(with: 462)    // 21
 BigInt(-12).greatestCommonDivisor(with: 18)      // 6   -- always non-negative
 ```
 
+There is a `**` operator for `power(_:)`, in a separate module so that it stays
+off unless imported — see [the README](README.md#the-exponentiation-operator-on-demand).
+
 `squareRoot()` is ⌊√self⌋ by Newton's method and traps on a negative value.
 `greatestCommonDivisor(with:)` is Stein's binary GCD, working on the limbs
 directly — it is on `BigRat`'s hot path, since every rational reduces on

--- a/Package.swift
+++ b/Package.swift
@@ -9,16 +9,27 @@ let package = Package(
         .library(
             name: "BigNum",
             targets: ["BigNum"]),
+        // `**`, which is off unless you import it.  Swift has no submodules, so
+        // an opt-in operator has to be an opt-in module.
+        .library(
+            name: "BigNumOperators",
+            targets: ["BigNumOperators"]),
     ],
     dependencies: [],
     targets: [
         .target(
             name: "BigNum"),
         .target(
+            name: "BigNumOperators",
+            dependencies: ["BigNum"]),
+        .target(
             name: "BigNumRun",
             dependencies: ["BigNum"]),
         .testTarget(
             name: "BigNumTests",
             dependencies: ["BigNum"]),
+        .testTarget(
+            name: "BigNumOperatorsTests",
+            dependencies: ["BigNumOperators"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -68,6 +68,36 @@ modular form never overflows, which is what makes it worth having.
 [BigInt.md](BigInt.md#on-the-built-in-integers-too) has the full table of which
 operations can trap.
 
+## The exponentiation operator, on demand
+
+`**` is not part of `BigNum`. It lives in a second module, so it appears only
+where you ask for it:
+
+```swift
+import BigNum                 // no ** in scope
+import BigNumOperators        // ** available, and BigNum comes with it
+```
+
+```swift
+2 ** 10                       // 1024              -- Int.power(10)
+BigInt(2) ** 256              // exact              -- BigInt.power(256)
+2.0 ** 0.5                    // 1.4142135623730951 -- Double.pow(2, 0.5)
+BigFloat(2) ** 10             // 1024               -- BigFloat.pow(x, 10)
+```
+
+It forwards to `power` on the integers and to `pow` on the `Real`s, and carries
+whatever those carry: `Int(2) ** 1024` traps like `*`, and `**` on a `BigRat`
+rounds to `precision` bits — it is `pow`, not repeated multiplication, so
+`BigRat(1,3) ** 2` is not `(1/9)` while `BigRat(1,3) * BigRat(1,3)` is.
+
+Two notes on parsing. `**` binds tighter than `*` and associates to the right, so
+`2 ** 3 ** 2` is 512. But Swift binds prefix `-` tighter than any infix operator,
+so `-2 ** 2` is 4 where Python says -4; write `-(2 ** 2)` when you mean that.
+
+Swift has no submodules, so `import BigNum.operators` is not a spelling that can
+be built — a separate module is what the language offers, and it gates the
+operator exactly the way you would want.
+
 ## `over`: fractions from integers
 
 `over(_:)` is the idiomatic way to build a rational. It reads as the fraction bar —

--- a/Sources/BigNumOperators/Exponentiation.swift
+++ b/Sources/BigNumOperators/Exponentiation.swift
@@ -1,0 +1,84 @@
+//
+//  Exponentiation.swift -- the `**` operator, for those who want it.
+//
+//  This is a module of its own so that it stays off unless asked for:
+//
+//      import BigNum                 // no ** in sight
+//      import BigNumOperators        // ** available, BigNum re-exported
+//
+//  Swift has no submodules, so `import BigNum.operators` is not a spelling that
+//  can be built.  `import Module.Decl` does parse -- it is a scoped import, and
+//  what it scopes is declarations, not operators -- so it could not gate this
+//  either.  A separate module is the mechanism the language actually offers, and
+//  it gates cleanly: an operator declaration is visible only to files that import
+//  the module declaring it.
+//
+//  `**` is not in the standard library on purpose, and the reasons are worth
+//  knowing before you turn it on:
+//
+//   *  There is no exponentiation precedence group, so this file declares one.
+//      Two modules that each declare their own and disagree cannot be imported
+//      into the same file.
+//   *  Swift binds prefix `-` tighter than any infix operator, so `-2 ** 2` is
+//      `(-2) ** 2`, which is 4.  Python says -4.  There is no fixing this from
+//      here; write `-(2 ** 2)` when you mean it.
+//
+//  What it forwards to, and nothing more:
+//
+//      2 ** 10                  // Int.power(10)      -- 1024
+//      BigInt(2) ** 256         // BigInt.power(256)  -- exact
+//      2.0 ** 0.5               // Double.pow(2, 0.5) -- 1.4142135623730951
+//      BigRat(1,3) ** 2         // BigRat.pow(x, 2)   -- rounded, see below
+//
+//  So every rule those carry, `**` carries.  An integer `**` traps on overflow
+//  the way `*` does, and a negative integer exponent gives 0 for anything but
+//  ±1.  On a `Real` it is `pow`, which rounds to `precision` bits -- and that is
+//  worth spelling out for `BigRat`, whose `*` does not:
+//
+//      BigRat(1,3) * BigRat(1,3)   // (1/9), exact
+//      BigRat(1,3) ** 2            // 1/9 rounded to 128 bits, which is not (1/9)
+//      BigRat(1,2) ** 3            // (1/8) -- exact, but only because the
+//                                  //   denominator is already a power of two
+//
+//  `**` is not repeated multiplication on those types.  Reach for `*`, or for
+//  `pow(_:_:precision:)`, when the rounding is the thing you care about.
+//
+
+@_exported import BigNum
+
+/// Binds tighter than `*`, and to the right, so `2 ** 3 ** 2` is `2 ** 9`.
+/// Both match ordinary mathematical notation, and Python.
+precedencegroup ExponentiationPrecedence {
+    associativity: right
+    higherThan: MultiplicationPrecedence
+}
+
+infix operator ** : ExponentiationPrecedence
+
+// MARK: - integers: b.power(e)
+
+/// `Int`, `UInt`, `Int8` ... `UInt64`, `Int128`.  Traps on overflow, as `power`
+/// and `*` both do -- `2 ** 1024` is not a number an `Int` has.
+public func ** <T:FixedWidthInteger>(_ base: T, _ exponent: Int) -> T {
+    return base.power(exponent)
+}
+
+/// `BigInt` and `BigUInt`, where nothing overflows.
+public func ** <T:BigIntegerType>(_ base: T, _ exponent: Int) -> T {
+    return base.power(exponent)
+}
+
+// MARK: - floating point: pow(b, e)
+
+/// `Double`, `BigRat` and `BigFloat` -- every `Real`.  The arbitrary-precision
+/// two work to `Self.precision` bits; call `pow(_:_:precision:)` directly when you
+/// want to say how many.
+public func ** <T:Real>(_ base: T, _ exponent: T) -> T {
+    return T.pow(base, exponent)
+}
+
+/// An integer exponent, which is exact where the general form would iterate: this
+/// is `pow(x, n)`, not `pow(x, T(n))`.
+public func ** <T:Real>(_ base: T, _ exponent: Int) -> T {
+    return T.pow(base, exponent)
+}

--- a/Tests/BigNumOperatorsTests/ExponentiationTests.swift
+++ b/Tests/BigNumOperatorsTests/ExponentiationTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import BigNumOperators
+
+///
+/// `**` forwards and nothing else, so every test here is "the operator agrees
+/// with the call it stands for".  What is worth pinning is the parsing: which
+/// overload a literal picks, and how the precedence group binds.
+///
+/// That this module exists at all is the feature -- `2 ** 3` does not compile
+/// against `import BigNum` alone.  A unit test cannot assert a compile failure,
+/// so that half is checked by building a file that tries it.
+///
+/// **Every floating-point operand below is explicitly typed, and must stay that
+/// way.**  Inside a `#expect` the `FloatLiteralType = Double` default does not
+/// apply, so an all-literal `4.0 ** 0.5 == 2.0` is free to resolve to any `Real`
+/// -- and it picks `BigFloat`, whose `pow(4, 0.5)` is a 128-bit approximation
+/// that prints as "2.0" and compares unequal to 2.  The test then fails while
+/// reporting `(4.0 ** 0.5 → 2.0) == 2.0`, which is as confusing as it sounds.
+/// Annotating the type is not defensive style here; it is the difference between
+/// testing `Double` and testing something else.  The same macro also cannot
+/// expand a custom operator alongside `&&`, so conditions are one per `#expect`.
+///
+@Suite struct ExponentiationTests {
+
+    @Test func integersForwardToPower() {
+        #expect(2 ** 10 == 1024)
+        #expect(2 ** 10 == Int(2).power(10))
+        #expect(Int(-2) ** 3 == -8)
+        #expect(UInt8(3) ** 5 == 243)
+        #expect(UInt(2) ** 63 == 9223372036854775808)
+        #expect(Int8(11) ** 2 == 121)
+        #expect(Int32(7) ** 3 == 343)
+        // BigInt and BigUInt, where nothing overflows
+        #expect(BigInt(2) ** 256 == BigInt(2).power(256))
+        #expect((BigInt(2) ** 256).description.count == 78)
+        #expect(BigUInt(2) ** 128 == BigUInt(1) << 128)
+        #expect(BigInt(-2) ** 255 == -(BigInt(2) ** 255))
+        // The edges `power` already has.  One condition per #expect on purpose:
+        // the swift-testing macro cannot expand a custom operator alongside `&&`
+        // -- `#expect(2 ** 1 == 2 && 2 ** 2 == 4)` does not compile, though the
+        // same expression outside a macro parses correctly.
+        #expect(Int(5) ** 0 == 1)
+        #expect(Int(5) ** 1 == 5)
+        #expect(Int(5) ** -2 == 0, "no integral reciprocal, as power(_:) says")
+        #expect(BigInt(1) ** -9 == 1)
+        #expect(BigInt(-1) ** -9 == -1)
+    }
+
+    @Test func floatingPointForwardsToPow() {
+        let two: Double = 2.0, nine: Double = 9.0, half: Double = 0.5
+        #expect(two ** half == Double.pow(2.0, 0.5))
+        #expect(two ** half == two.squareRoot())
+        #expect(two ** 10 == 1024.0)
+        #expect(two ** 10 == Double.pow(2.0, 10))
+        #expect(nine ** half == 3.0)
+        // the arbitrary-precision Reals forward to their own pow
+        #expect(BigRat(2) ** 10 == BigRat.pow(BigRat(2), 10))
+        #expect(BigFloat(2) ** 10 == BigFloat.pow(BigFloat(2), 10))
+        #expect(BigFloat(2) ** BigFloat(0.5) == BigFloat.pow(BigFloat(2), BigFloat(0.5)))
+        #expect(BigRat(2) ** 10 == 1024)
+        #expect(BigFloat(2) ** 10 == 1024)
+    }
+
+    /// `**` on a `Real` is `pow`, and `pow` on these types rounds to `precision`
+    /// bits.  It is *not* repeated multiplication, which matters most where you
+    /// would least expect it: on `BigRat`, whose `*` is exact.
+    @Test func realExponentiationRoundsAndIsNotRepeatedMultiplication() {
+        // exact, because a power-of-two denominator survives truncation
+        #expect(BigRat(1,2) ** 3 == BigRat(1,8))
+        #expect(BigRat(2) ** 10 == 1024)
+        // not exact, because 1/9 does not
+        #expect(BigRat(1,3) * BigRat(1,3) == BigRat(1,9), "multiplication is exact")
+        #expect(BigRat(1,3) ** 2 != BigRat(1,9), "pow is not -- it rounds to 128 bits")
+        #expect(BigRat(1,3) ** 2 == BigRat.pow(BigRat(1,3), 2), "and `**` is exactly that pow")
+        #expect(BigRat(1,3) ** 2 == BigRat(1,3).power(2), "which is power(_:precision:)")
+        // near enough to be a rounding difference and no more
+        let err = (BigRat(1,3) ** 2 - BigRat(1,9)).magnitude
+        #expect(err < BigRat.getEpsilon(precision: 120), "\(err) should be a 128-bit rounding")
+        // BigFloat rounds too, and prints as though it had not
+        #expect(BigFloat.pow(BigFloat(4), BigFloat(0.5)).description == "2.0")
+        #expect(BigFloat.pow(BigFloat(4), BigFloat(0.5)) != 2, "which is worth knowing")
+    }
+
+    /// Which overload a bare literal picks.  `2 ** 3` has four candidates -- Int
+    /// or Double base, Int or Double exponent -- and the default literal type has
+    /// to settle it, or the call is ambiguous.
+    @Test func literalsResolveWithoutAnnotation() {
+        // bound to a `let` first, which is where the ordinary literal defaults
+        // apply -- see the note on this suite about doing it inside #expect
+        let i = 2 ** 3
+        #expect(i == 8)
+        #expect(type(of: i) == Int.self, "an all-integer literal expression is Int")
+        let d = 2.0 ** 3
+        #expect(d == 8.0)
+        #expect(type(of: d) == Double.self, "and an all-float one is Double")
+        let e = 2.0 ** 3.0
+        #expect(type(of: e) == Double.self)
+        #expect(e == 8.0)
+        // explicit types on either side still resolve
+        let big: BigInt = 2
+        #expect(big ** 10 == 1024)
+        let rat: BigRat = 2
+        #expect(rat ** 10 == 1024)
+        let f: BigFloat = 2
+        #expect(f ** 10 == 1024)
+    }
+
+    /// Right associative and tighter than `*`, which is the whole reason to
+    /// declare a precedence group rather than reuse an existing one.
+    @Test func precedenceAndAssociativity() {
+        #expect(2 ** 3 ** 2 == 512, "right associative: 2 ** (3 ** 2)")
+        #expect(2 ** 3 ** 2 != 64, "not (2 ** 3) ** 2")
+        #expect(2 * 3 ** 2 == 18, "tighter than *: 2 * (3 ** 2)")
+        #expect(3 ** 2 * 2 == 18)
+        #expect(1 + 2 ** 3 == 9, "tighter than +")
+        #expect(2 ** 3 + 1 == 9)
+        #expect(-2 ** 2 == 4, "prefix minus binds tighter in Swift, unlike Python's -4")
+        #expect(Int(-2) ** 2 == 4)
+        #expect(-(2 ** 2) == -4, "which is how to say the other thing")
+        #expect(2 ** 2 ** 3 == 256, "2 ** 8")
+        #expect(BigInt(2) ** 2 ** 3 == 256, "and the same for BigInt")
+    }
+
+    /// The operator is a forwarder, so it inherits every semantic of the thing it
+    /// forwards to -- including the ones that trap.  Those are checked by running
+    /// them out of process; here we pin the boundary just inside.
+    @Test func inheritsThePropertiesOfWhatItForwardsTo() {
+        #expect(Int(2) ** 62 == 4611686018427387904, "the largest power of two an Int holds")
+        #expect(BigInt(2) ** 1024 == BigInt(1) << 1024, "no ceiling here")
+        // floating point rounds, exact arithmetic does not
+        #expect(BigFloat(1) / BigFloat(3) * 3 != 1)
+        #expect(BigRat(1) / BigRat(3) * 3 == 1)
+    }
+}


### PR DESCRIPTION
## What

```swift
import BigNum                 // no ** in scope
import BigNumOperators        // ** available, and BigNum comes with it
```

```swift
2 ** 10                       // 1024               -- Int.power(10)
BigInt(2) ** 256              // exact              -- BigInt.power(256)
2.0 ** 0.5                    // 1.4142135623730951 -- Double.pow(2, 0.5)
BigFloat(2) ** 10             // 1024               -- BigFloat.pow(x, 10)
```

A new `BigNumOperators` target and product, which re-exports `BigNum` so one import is enough. `**` gets its own precedence group: right associative, tighter than `*`, so `2 ** 3 ** 2` is 512.

## The requested spelling can't be built

The ask was `import BigNum.operators`. Swift has no submodules, and the compiler agrees — `no such module 'BigNum.operators'`. `import Module.Decl` does parse, but it is a *scoped import* and what it scopes is declarations, not operators, so it could not gate this either. A separate module is the mechanism the language offers.

I verified the gate from a real consumer package rather than assuming it: with only `import BigNum`, `BigInt(2) ** 10` fails with **"cannot find operator '**' in scope"**; switching the dependency to `BigNumOperators` builds and runs. Rename the product if you'd prefer something else — nothing depends on the name yet.

## Two things a reviewer should know

**`#expect` resolves bare float literals to the wrong type.** Inside the macro the `FloatLiteralType = Double` default does not apply, so `T: Real` is unconstrained and Swift picks `BigFloat` — whose `pow(4, 0.5)` is a 128-bit approximation that *prints* as "2.0" and compares unequal to 2. `#expect(4.0 ** 0.5 == 2.0)` then fails reporting `(4.0 ** 0.5 → 2.0) == 2.0`, which reads like nonsense. My first draft of these tests was therefore testing `BigFloat` while appearing to test `Double`. Every floating-point operand is now explicitly typed, with a comment in the suite explaining that this is not style but the difference between testing one type and another. Parenthesising does not help; binding to a `let` does. The same macro also cannot expand a custom operator alongside `&&`, so conditions are one per `#expect`.

**`**` on a `BigRat` rounds.** It is `pow`, which routes through `power(_:precision:)`, so `BigRat(1,3) ** 2` is 1/9 truncated to 128 bits while `BigRat(1,3) * BigRat(1,3)` is exactly `(1/9)`. This is pre-existing behaviour of `BigRat.pow`, not something the operator introduces — but the operator makes it easy to hit by accident, so it is called out in both the module comment and the README. My first module comment illustrated with `BigRat(1,2) ** 3 // (1/8)`, exact *only* because that denominator is already a power of two; replaced with the pair that shows the difference. If you would rather `**` on a rational meant exact repeated multiplication, that is a real design question and a different one from what was asked.

## Also documented

Swift binds prefix `-` tighter than any infix operator, so `-2 ** 2` is 4 where Python says -4. Write `-(2 ** 2)` for the other reading. There is no fixing this from a library.

## Testing

73 tests pass. The operator tests cover forwarding for every integer width and every `Real`, the precedence and associativity, which overload a literal picks (via `let` bindings and `type(of:)`, where the ordinary defaults apply), and the rounding behaviour above. All documented examples verified by execution; all six playground pages still compile and run.

The playgrounds are otherwise untouched: a page using `**` would need a second import, which changes how those pages are set up. Happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)