### PR TITLE
Benchmark BigInt against attaswift/BigInt, on demand

### DIFF
--- a/Benchmark.md
+++ b/Benchmark.md
@@ -1,0 +1,210 @@
+# Benchmark
+
+`BigInt` here against [attaswift/BigInt], the dependency this package used to
+have. Same inputs, same machine, same run.
+
+**This is not part of `swift test`.** The benchmark is a package of its own, so
+running it is something you ask for:
+
+```bash
+cd Benchmarks && swift run -c release
+```
+
+It has to be its own package rather than a target in the root manifest, because
+SwiftPM resolves every declared dependency whether or not the target using it is
+being built — a benchmark target at the root would quietly end the "`swift build`
+fetches nothing" property. Nothing in `Benchmarks/` is reachable from the root
+package.
+
+## The one thing to read if you read nothing else
+
+**The two libraries disagree on `>>` for negative values, and attaswift is the
+one that departs from the standard library.** `Int` shifts arithmetically — it
+floors — and so does this package. attaswift shifts the magnitude and keeps the
+sign, which truncates toward zero:
+
+| value | `Int` | swift-bignum | attaswift |
+|---:|---:|---:|---:|
+| -1 | -1 | -1 | -1 |
+| -2 | -1 | -1 | -1 |
+| -3 | -2 | -2 | -1 **differs** |
+| -5 | -3 | -3 | -2 **differs** |
+| -7 | -4 | -4 | -3 **differs** |
+| -8 | -4 | -4 | -4 |
+| -1025 | -513 | -513 | -512 **differs** |
+
+swift-bignum matches `Int` in 7 of 7 cases; attaswift in 3.
+
+`BinaryInteger` specifies the flooring behaviour, which is why this package
+matches `Int` exactly. If you are porting code off attaswift and it right-shifts
+negative numbers, the results will change — and they will change to the answers
+`Int` would have given. This is the only behavioural disagreement the benchmark
+found across 75 cases; the `>> (negative)` rows below are therefore marked `n/c`,
+since timing two functions that compute different things is not a comparison.
+
+## Where each one wins
+
+Ratios are attaswift's time over ours, so **greater than 1 means swift-bignum is
+faster**. Anything within about 1.15× is noise (run-to-run variation on the same
+machine was under 5%).
+
+| operation | 64 bits | 256 bits | 1024 bits | 4096 bits |
+|---|---:|---:|---:|---:|
+| `+` | **1.48×** | **2.15×** | **2.27×** | **1.98×** |
+| `-` | 0.56× | 0.63× | 0.70× | 0.85× |
+| `*` | 0.48× | 1.09× | **2.74×** | **4.01×** |
+| `* (negative)` | 0.49× | 1.10× | **2.54×** | **3.87×** |
+| `/` | 0.47× | 0.77× | **1.42×** | **3.07×** |
+| `%` | 0.56× | 0.67× | **1.35×** | **3.04×** |
+| `<` | **1.20×** | **1.20×** | **1.20×** | **1.20×** |
+| `<< 61` | 0.60× | **1.36×** | **3.23×** | **5.38×** |
+| `>> 61` | 0.60× | 1.04× | **1.22×** | **1.37×** |
+| `>> 61 (negative)` | n/c | n/c | n/c | n/c |
+| `& (negative)` | **1.70×** | **1.84×** | **2.05×** | **1.93×** |
+| `~ (negative)` | **1.31×** | **1.32×** | **1.18×** | 0.93× |
+| `description` | 0.48× | 0.45× | 0.59× | 0.97× |
+| `init(radix: 10)` | 0.50× | 0.63× | 0.70× | 0.76× |
+| `init(radix: 16)` | 0.44× | 0.59× | 0.62× | 0.58× |
+| `squareRoot` | **6.67×** | 0.71× | 0.96× | **1.74×** |
+| `gcd` | **1.60×** | **2.38×** | **2.85×** | **1.59×** |
+| `power(5)` | 0.44× | **2.11×** | **9.06×** | **5.11×** |
+| `power(e, mod:)` | 0.42× | 0.93× | **1.33×** | — |
+
+The pattern is asymptotic against constant. **swift-bignum wins as operands grow
+and loses at one or two limbs**, and the crossover is visible in `*` (0.48× at 64
+bits, 4.01× at 4096) and in `/` and `%`. Karatsuba above 40 limbs is part of it;
+the rest is that attaswift's per-call overhead is lower and ours does not shrink
+with the operand. `<< 61` costs us 166 ns on one limb and 275 ns on 64 of them —
+a 64× larger input for 1.7× the time — which is a fixed cost per call, not work.
+
+Three groups stand out:
+
+* **Two's complement pays where it should.** `+`, `&` and `~` on negative values
+  read straight off the storage, with no sign to case-analyse: 1.5–2.3× on `+`
+  and 1.7–2.1× on `&` at every size. That was the reason for the representation
+  and it shows up as expected.
+* **`power` and `gcd` are the largest wins.** `power(5)` is 9× at 1024 bits, and
+  Stein's binary gcd on the limbs is 1.6–2.9× throughout.
+* **String conversion is the standing loss.** Both parsers are 0.44–0.76× at
+  every size, and `description` is 0.45–0.59× until it reaches parity at 4096
+  bits. Chunking by the largest power of the radix that fits a limb was supposed
+  to settle this and evidently does not; attaswift is simply better at it.
+
+## Two things this measured that look fixable
+
+Neither is a design consequence, so they are worth recording as leads rather than
+as facts about two's complement:
+
+* **`-` is `lhs + (-rhs)`.** That is two passes over the limbs and two
+  allocations where one of each would do, and it shows: our `-` costs 2.3–2.5×
+  our `+` at every size, while attaswift's `-` is never slower than its `+`. It
+  is the only arithmetic operation we lose at *every* size — and we win `+`
+  everywhere by 1.5–2.3×, so the subtraction is leaving that on the table.
+* **Small operands carry a constant we do not need.** Most of the 64-bit losses
+  are in the 100–170 ns range against attaswift's ~100 ns, on work that is a
+  handful of instructions. Allocation per result is the obvious suspect.
+
+## Method
+
+* Both libraries parse the *same* hex string for each input, so neither is handed
+  a representation the other has to convert first.
+* Every case is checked for agreement **before** it is timed, and disagreements
+  are reported rather than averaged away. This is how the `>>` difference above
+  surfaced — it was not something either library documented.
+* Iteration count scales until a batch takes 50 ms, then the best of five batches
+  is reported. Best-of rather than mean, because interference can only make a
+  batch slower.
+* Every result is folded into a checksum that gets printed, so nothing measured
+  is dead code.
+* A debug build reports the absence of the optimizer rather than the algorithms,
+  so the harness says so loudly if it is built without `-c release`.
+
+Measured on an Apple M1 (8 cores), macOS 26.6.1, Swift 6.3.3, against
+attaswift/BigInt **5.7.0**. `Package.resolved` is not checked in, so a later run
+may pick up a newer 5.x — `swift package resolve && cat Package.resolved` in
+`Benchmarks/` says which version you actually got.
+
+Absolute times, as generated:
+
+| operation | bits | swift-bignum | attaswift | ratio |
+| `+` | 64 | 75 ns | 111 ns | **1.48×** |
+| `-` | 64 | 189 ns | 105 ns | 0.56× |
+| `*` | 64 | 223 ns | 108 ns | 0.49× |
+| `* (negative)` | 64 | 220 ns | 108 ns | 0.49× |
+| `/` | 64 | 272 ns | 128 ns | 0.47× |
+| `%` | 64 | 272 ns | 153 ns | 0.56× |
+| `<` | 64 | 5 ns | 6 ns | **1.12×** |
+| `<< 61` | 64 | 166 ns | 99 ns | 0.60× |
+| `>> 61` | 64 | 165 ns | 99 ns | 0.60× |
+| `>> 61 (negative)` | 64 | 166 ns | 99 ns | not comparable |
+| `& (negative)` | 64 | 73 ns | 124 ns | **1.70×** |
+| `~ (negative)` | 64 | 72 ns | 94 ns | **1.31×** |
+| `description` | 64 | 892 ns | 424 ns | 0.48× |
+| `init(radix: 10)` | 64 | 1.95 µs | 969 ns | 0.50× |
+| `init(radix: 16)` | 64 | 1.72 µs | 762 ns | 0.44× |
+| `squareRoot` | 64 | 137 ns | 914 ns | **6.65×** |
+| `gcd` | 64 | 783 ns | 1.25 µs | **1.60×** |
+| `power(5)` | 64 | 1.59 µs | 692 ns | 0.44× |
+| `power(e, mod:)` | 64 | 99.91 µs | 41.58 µs | 0.42× |
+| `+` | 256 | 79 ns | 170 ns | **2.16×** |
+| `-` | 256 | 195 ns | 122 ns | 0.63× |
+| `*` | 256 | 303 ns | 331 ns | **1.09×** |
+| `* (negative)` | 256 | 302 ns | 331 ns | **1.09×** |
+| `/` | 256 | 906 ns | 694 ns | 0.77× |
+| `%` | 256 | 905 ns | 610 ns | 0.67× |
+| `<` | 256 | 5 ns | 6 ns | **1.19×** |
+| `<< 61` | 256 | 169 ns | 229 ns | **1.35×** |
+| `>> 61` | 256 | 168 ns | 175 ns | **1.04×** |
+| `>> 61 (negative)` | 256 | 168 ns | 175 ns | not comparable |
+| `& (negative)` | 256 | 73 ns | 134 ns | **1.84×** |
+| `~ (negative)` | 256 | 71 ns | 94 ns | **1.32×** |
+| `description` | 256 | 2.60 µs | 1.18 µs | 0.46× |
+| `init(radix: 10)` | 256 | 4.76 µs | 3.02 µs | 0.63× |
+| `init(radix: 16)` | 256 | 4.20 µs | 2.49 µs | 0.59× |
+| `squareRoot` | 256 | 6.05 µs | 4.28 µs | 0.71× |
+| `gcd` | 256 | 3.09 µs | 7.35 µs | **2.38×** |
+| `power(5)` | 256 | 1.61 µs | 3.40 µs | **2.12×** |
+| `power(e, mod:)` | 256 | 933.72 µs | 868.71 µs | 0.93× |
+| `+` | 1024 | 95 ns | 216 ns | **2.27×** |
+| `-` | 1024 | 232 ns | 163 ns | 0.70× |
+| `*` | 1024 | 583 ns | 1.60 µs | **2.74×** |
+| `* (negative)` | 1024 | 630 ns | 1.60 µs | **2.54×** |
+| `/` | 1024 | 2.50 µs | 3.55 µs | **1.42×** |
+| `%` | 1024 | 2.52 µs | 3.41 µs | **1.36×** |
+| `<` | 1024 | 5 ns | 6 ns | **1.12×** |
+| `<< 61` | 1024 | 183 ns | 591 ns | **3.22×** |
+| `>> 61` | 1024 | 181 ns | 221 ns | **1.23×** |
+| `>> 61 (negative)` | 1024 | 182 ns | 221 ns | not comparable |
+| `& (negative)` | 1024 | 85 ns | 174 ns | **2.06×** |
+| `~ (negative)` | 1024 | 78 ns | 92 ns | **1.18×** |
+| `description` | 1024 | 9.41 µs | 5.56 µs | 0.59× |
+| `init(radix: 10)` | 1024 | 16.09 µs | 11.25 µs | 0.70× |
+| `init(radix: 16)` | 1024 | 15.02 µs | 9.30 µs | 0.62× |
+| `squareRoot` | 1024 | 15.12 µs | 14.46 µs | 0.96× |
+| `gcd` | 1024 | 23.72 µs | 67.59 µs | **2.85×** |
+| `power(5)` | 1024 | 4.61 µs | 41.76 µs | **9.07×** |
+| `power(e, mod:)` | 1024 | 25.63 ms | 34.21 ms | **1.33×** |
+| `+` | 4096 | 190 ns | 377 ns | **1.99×** |
+| `-` | 4096 | 437 ns | 371 ns | 0.85× |
+| `*` | 4096 | 6.17 µs | 24.76 µs | **4.02×** |
+| `* (negative)` | 4096 | 6.38 µs | 24.70 µs | **3.87×** |
+| `/` | 4096 | 16.06 µs | 49.27 µs | **3.07×** |
+| `%` | 4096 | 15.96 µs | 48.53 µs | **3.04×** |
+| `<` | 4096 | 5 ns | 6 ns | **1.19×** |
+| `<< 61` | 4096 | 275 ns | 1.48 µs | **5.37×** |
+| `>> 61` | 4096 | 264 ns | 362 ns | **1.37×** |
+| `>> 61 (negative)` | 4096 | 264 ns | 363 ns | not comparable |
+| `& (negative)` | 4096 | 189 ns | 365 ns | **1.93×** |
+| `~ (negative)` | 4096 | 108 ns | 100 ns | 0.93× |
+| `description` | 4096 | 52.84 µs | 51.46 µs | 0.97× |
+| `init(radix: 10)` | 4096 | 65.92 µs | 50.06 µs | 0.76× |
+| `init(radix: 16)` | 4096 | 61.88 µs | 36.13 µs | 0.58× |
+| `squareRoot` | 4096 | 93.00 µs | 161.84 µs | **1.74×** |
+| `gcd` | 4096 | 551.89 µs | 876.29 µs | **1.59×** |
+| `power(5)` | 4096 | 134.93 µs | 689.73 µs | **5.11×** |
+
+Ours and theirs are `BigInt` in both cases: signed, arbitrary precision. Both
+libraries are being asked for the same answers, and — apart from the one row
+above — both give them.
+
+[attaswift/BigInt]: https://github.com/attaswift/BigInt

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.9
+//
+// A package of its own, deliberately.  swift-bignum's own manifest has no
+// dependencies and `swift build` at the root fetches nothing -- that is a
+// property worth keeping, and a benchmark target in the root manifest would
+// quietly end it, since SwiftPM resolves every declared dependency whether the
+// target using it is being built or not.
+//
+// So: run the benchmark by asking for it.
+//
+//     cd Benchmarks && swift run -c release
+//
+import PackageDescription
+
+let package = Package(
+    name: "BigNumBenchmark",
+    dependencies: [
+        .package(path: ".."),
+        .package(url: "https://github.com/attaswift/BigInt.git", from: "5.7.0"),
+    ],
+    targets: [
+        // See Sources/Attaswift: both libraries want the name `BigInt`, and only
+        // a benchmark ever needs them in the same file.
+        .target(
+            name: "Attaswift",
+            dependencies: [.product(name: "BigInt", package: "BigInt")]),
+        .executableTarget(
+            name: "BigNumBenchmark",
+            dependencies: [
+                .product(name: "BigNum", package: "swift-bignum"),
+                "Attaswift",
+            ]),
+    ]
+)

--- a/Benchmarks/Sources/Attaswift/Attaswift.swift
+++ b/Benchmarks/Sources/Attaswift/Attaswift.swift
@@ -1,0 +1,23 @@
+//
+//  A one-line shim, and an unavoidable one.
+//
+//  attaswift's module is named `BigInt` and so is its main type, and swift-bignum
+//  contains a class named `BigNum` -- so in a file importing both, neither
+//  `BigInt.BigInt` nor `BigNum.BigInt` resolves: the first is ambiguous and the
+//  second finds the class.  SwiftPM's `moduleAliases` looked like the answer and
+//  is not (it renames the module but still insists on the original spelling at
+//  the import).
+//
+//  Inside *this* module only attaswift is imported, so its `BigInt` is simply
+//  what `BigInt` means -- no qualifying needed, which is the whole trick.  (Not
+//  even `BigInt.BigInt` works here: the type shadows the module.)
+//
+//  This is the same collision that made swift-bignum re-export attaswift's BigInt
+//  with `@_exported import` back when it was a dependency -- the thing the
+//  README calls an undocumented acrobat.  Two libraries cannot both own the name
+//  `BigInt` in one file, and only a benchmark ever wants them to.
+//
+import BigInt
+
+public typealias AttaswiftBigInt = BigInt
+public typealias AttaswiftBigUInt = BigUInt

--- a/Benchmarks/Sources/BigNumBenchmark/main.swift
+++ b/Benchmarks/Sources/BigNumBenchmark/main.swift
@@ -1,0 +1,268 @@
+//
+//  BigNum's BigInt against attaswift/BigInt.
+//
+//  Run it with `swift run -c release` from the Benchmarks directory.  A debug
+//  build measures the optimizer's absence, not the algorithms -- generic
+//  specialization is most of what makes either library fast -- so this refuses
+//  to report numbers from one.
+//
+//  Method, such as it is:
+//
+//   *  Both libraries get the *same* inputs, built by parsing one hex string
+//      each, so neither is handed a representation the other has to convert.
+//   *  Every case is checked for agreement before it is timed.  A benchmark of
+//      two functions that compute different things is worthless, and this
+//      doubles as a differential test against a mature implementation.
+//   *  Iteration count scales until a batch takes 50ms, then the best of five
+//      batches is reported.  Best-of rather than mean: the distribution is
+//      one-sided, since interference can only slow a batch down.
+//   *  Every result is folded into a checksum that gets printed, so nothing
+//      being measured is dead code.
+//
+//  What the numbers are not: a verdict.  attaswift/BigInt is sign-and-magnitude
+//  and this is two's complement, which is a design difference with a cost on
+//  each side, and neither library has been tuned against the other.
+//
+
+import Foundation
+import BigNum
+import Attaswift
+
+typealias Ours = BigInt              // swift-bignum's
+typealias Theirs = AttaswiftBigInt   // attaswift's, renamed by the shim
+
+// MARK: - plumbing
+
+/// Everything measured folds into here, so the optimizer cannot delete it.
+var checksum: UInt64 = 0
+
+@inline(__always) func fold(_ v: Ours) -> UInt64 {
+    return UInt64(truncatingIfNeeded: v.words.first ?? 0) ^ UInt64(v.words.count)
+}
+@inline(__always) func fold(_ v: Theirs) -> UInt64 {
+    return UInt64(truncatingIfNeeded: v.words.first ?? 0) ^ UInt64(v.words.count)
+}
+@inline(__always) func fold(_ v: Bool) -> UInt64 { return v ? 1 : 0 }
+@inline(__always) func fold(_ v: String) -> UInt64 { return UInt64(v.utf8.count) }
+
+/// Splitmix64, so the inputs are the same on every machine and every run.
+struct Random {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+    /// A hex string of exactly `bits` bits, top bit set so the width is honest.
+    mutating func hex(bits: Int) -> String {
+        var s = ""
+        var remaining = bits
+        while remaining > 0 {
+            let take = Swift.min(64, remaining)
+            var word = next()
+            if remaining == bits {                      // the top chunk
+                word |= 1 << UInt64(take - 1)           // ... has its top bit set
+                if take < 64 { word &= (1 << UInt64(take)) - 1 }
+            }
+            s += String(word, radix: 16)
+                   .leftPadded(to: remaining == bits ? (take + 3) / 4 : 16)
+            remaining -= take
+        }
+        return s
+    }
+}
+
+extension String {
+    func leftPadded(to n: Int) -> String {
+        return count >= n ? self : String(repeating: "0", count: n - count) + self
+    }
+}
+
+func measure(_ body: () -> UInt64) -> Double {
+    var n = 1
+    var elapsed: UInt64 = 0
+    while true {
+        let t0 = DispatchTime.now().uptimeNanoseconds
+        var acc: UInt64 = 0
+        for _ in 0 ..< n { acc = acc &+ body() }
+        elapsed = DispatchTime.now().uptimeNanoseconds - t0
+        checksum = checksum &+ acc
+        if elapsed >= 50_000_000 || n >= 1 << 28 { break }
+        n = elapsed < 1_000_000 ? n * 16 : n * 2
+    }
+    var best = Double(elapsed) / Double(n)
+    for _ in 0 ..< 4 {
+        let t0 = DispatchTime.now().uptimeNanoseconds
+        var acc: UInt64 = 0
+        for _ in 0 ..< n { acc = acc &+ body() }
+        let each = Double(DispatchTime.now().uptimeNanoseconds - t0) / Double(n)
+        checksum = checksum &+ acc
+        best = Swift.min(best, each)
+    }
+    return best
+}
+
+struct Result {
+    let op: String, bits: Int, ours: Double, theirs: Double, agreed: Bool
+}
+var results: [Result] = []
+
+/// Check first, then time.  `same` returns whether the two produced equal
+/// answers -- compared as decimal strings, the one representation both agree on.
+func bench(_ op: String, _ bits: Int,
+           same: () -> Bool,
+           ours: @escaping () -> UInt64,
+           theirs: @escaping () -> UInt64) {
+    let agreed = same()
+    if !agreed { FileHandle.standardError.write("DISAGREEMENT: \(op) at \(bits) bits\n".data(using: .utf8)!) }
+    let o = measure(ours)
+    let t = measure(theirs)
+    results.append(Result(op: op, bits: bits, ours: o, theirs: t, agreed: agreed))
+    let ratio = t / o
+    FileHandle.standardError.write(
+      String(format: "  %-22s %5d bits  ours %10.1f ns  theirs %10.1f ns  %5.2fx%@\n",
+             (op as NSString).utf8String!, bits, o, t, ratio,
+             agreed ? "" : "  ** DISAGREED **").data(using: .utf8)!)
+}
+
+// MARK: - the cases
+
+let sizes = [64, 256, 1024, 4096]
+
+for bits in sizes {
+    var rng = Random(seed: 0x5EED_0000 &+ UInt64(bits))
+    let ha = rng.hex(bits: bits), hb = rng.hex(bits: bits)
+    let hwide = rng.hex(bits: bits * 2)
+    let (oa, ob) = (Ours(ha, radix: 16)!, Ours(hb, radix: 16)!)
+    let (ta, tb) = (Theirs(ha, radix: 16)!, Theirs(hb, radix: 16)!)
+    let (owide, twide) = (Ours(hwide, radix: 16)!, Theirs(hwide, radix: 16)!)
+    // negatives, where two's complement and sign-and-magnitude actually differ
+    let (ona, onb) = (-oa, -ob)
+    let (tna, tnb) = (-ta, -tb)
+    let decimal = oa.description
+    precondition(decimal == ta.description, "inputs differ at \(bits) bits")
+
+    bench("+", bits, same: { (oa + ob).description == (ta + tb).description },
+          ours: { fold(oa + ob) }, theirs: { fold(ta + tb) })
+    bench("-", bits, same: { (oa - ob).description == (ta - tb).description },
+          ours: { fold(oa - ob) }, theirs: { fold(ta - tb) })
+    bench("*", bits, same: { (oa * ob).description == (ta * tb).description },
+          ours: { fold(oa * ob) }, theirs: { fold(ta * tb) })
+    bench("* (negative)", bits, same: { (ona * onb).description == (tna * tnb).description },
+          ours: { fold(ona * onb) }, theirs: { fold(tna * tnb) })
+    bench("/", bits, same: { (owide / ob).description == (twide / tb).description },
+          ours: { fold(owide / ob) }, theirs: { fold(twide / tb) })
+    bench("%", bits, same: { (owide % ob).description == (twide % tb).description },
+          ours: { fold(owide % ob) }, theirs: { fold(twide % tb) })
+    bench("<", bits, same: { (oa < ob) == (ta < tb) },
+          ours: { fold(oa < ob) }, theirs: { fold(ta < tb) })
+    bench("<< 61", bits, same: { (oa << 61).description == (ta << 61).description },
+          ours: { fold(oa << 61) }, theirs: { fold(ta << 61) })
+    bench(">> 61", bits, same: { (oa >> 61).description == (ta >> 61).description },
+          ours: { fold(oa >> 61) }, theirs: { fold(ta >> 61) })
+    // This one does not agree, and the disagreement is the point: `Int(-5) >> 1`
+    // is -3, and so is ours, while attaswift shifts the magnitude and keeps the
+    // sign, giving -2.  Timing it is still worth doing -- just not as a race.
+    bench(">> 61 (negative)", bits, same: { (ona >> 61).description == (tna >> 61).description },
+          ours: { fold(ona >> 61) }, theirs: { fold(tna >> 61) })
+    bench("& (negative)", bits, same: { (ona & onb).description == (tna & tnb).description },
+          ours: { fold(ona & onb) }, theirs: { fold(tna & tnb) })
+    bench("~ (negative)", bits, same: { (~ona).description == (~tna).description },
+          ours: { fold(~ona) }, theirs: { fold(~tna) })
+    bench("description", bits, same: { oa.description == ta.description },
+          ours: { fold(oa.description) }, theirs: { fold(ta.description) })
+    bench("init(radix: 10)", bits, same: { Ours(decimal)!.description == Theirs(decimal)!.description },
+          ours: { fold(Ours(decimal)!) }, theirs: { fold(Theirs(decimal)!) })
+    bench("init(radix: 16)", bits, same: { Ours(ha, radix: 16)!.description == Theirs(ha, radix: 16)!.description },
+          ours: { fold(Ours(ha, radix: 16)!) }, theirs: { fold(Theirs(ha, radix: 16)!) })
+    bench("squareRoot", bits, same: { oa.squareRoot().description == ta.squareRoot().description },
+          ours: { fold(oa.squareRoot()) }, theirs: { fold(ta.squareRoot()) })
+    bench("gcd", bits, same: { oa.greatestCommonDivisor(with: ob).description
+                                 == ta.greatestCommonDivisor(with: tb).description },
+          ours: { fold(oa.greatestCommonDivisor(with: ob)) },
+          theirs: { fold(ta.greatestCommonDivisor(with: tb)) })
+    bench("power(5)", bits, same: { oa.power(5).description == ta.power(5).description },
+          ours: { fold(oa.power(5)) }, theirs: { fold(ta.power(5)) })
+    // modular exponentiation, with the exponent the same width as the modulus --
+    // the shape RSA and Diffie-Hellman use.  Capped: at 4096 bits one call is
+    // seconds, and five batches of it says nothing the smaller sizes do not.
+    if bits <= 1024 {
+        bench("power(e, mod:)", bits,
+              same: { oa.power(ob, mod: owide).description
+                        == ta.power(tb, modulus: twide).description },
+              ours: { fold(oa.power(ob, mod: owide)) },
+              theirs: { fold(ta.power(tb, modulus: twide)) })
+    }
+}
+
+// MARK: - semantics, where a difference is not a matter of speed
+//
+// The benchmark above flags disagreements but cannot say who is right.  `Int` can:
+// the standard library specifies `>>` on a signed type as arithmetic, so whatever
+// `Int` does is the contract.
+
+func shiftSemantics() -> [(Int, String, String, String)] {
+    var out: [(Int, String, String, String)] = []
+    for v in [-1, -2, -3, -5, -7, -8, -1025] {
+        out.append((v, "\(v >> 1)", "\(Ours(v) >> 1)", "\(Theirs(v) >> 1)"))
+    }
+    return out
+}
+
+// MARK: - report
+
+#if DEBUG
+print("""
+    **This is a debug build and the numbers below are meaningless.**  Neither
+    library is specialized without the optimizer.  Re-run with:
+
+        swift run -c release
+    """)
+#endif
+
+let disagreements = results.filter { !$0.agreed }
+print("")
+print("| operation | bits | swift-bignum | attaswift | ratio |")
+print("|---|---:|---:|---:|---:|")
+func format(_ ns: Double) -> String {
+    if ns < 1000 { return String(format: "%.0f ns", ns) }
+    if ns < 1_000_000 { return String(format: "%.2f µs", ns / 1000) }
+    return String(format: "%.2f ms", ns / 1_000_000)
+}
+for r in results {
+    let ratio = r.theirs / r.ours
+    let verdict = !r.agreed
+      ? "not comparable"
+      : (ratio >= 1 ? String(format: "**%.2f×**", ratio)
+                    : String(format: "%.2f×", ratio))
+    print("| `\(r.op)` | \(r.bits) | \(format(r.ours)) | \(format(r.theirs)) | \(verdict) |")
+}
+print("")
+print("\(results.count) cases, \(results.count - disagreements.count) in agreement"
+        + (disagreements.isEmpty ? "." : "."))
+if !disagreements.isEmpty {
+    print("")
+    print("Disagreed, so no ratio is reported for them: "
+            + Set(disagreements.map { "`\($0.op)`" }).sorted().joined(separator: ", ") + ".")
+}
+let semantics = shiftSemantics()
+let deviating = semantics.filter { $0.1 != $0.3 }
+if !deviating.isEmpty {
+    print("")
+    print("`>> 1` against `Int`, which defines the contract:")
+    print("")
+    print("| value | `Int` | swift-bignum | attaswift |")
+    print("|---:|---:|---:|---:|")
+    for (v, i, o, t) in semantics {
+        print("| \(v) | \(i) | \(o)\(o == i ? "" : " **differs**") | \(t)\(t == i ? "" : " **differs**") |")
+    }
+    print("")
+    let oursOff = semantics.filter { $0.1 != $0.2 }.count
+    print("swift-bignum matches `Int` in \(semantics.count - oursOff) of \(semantics.count) cases; "
+            + "attaswift in \(semantics.count - deviating.count).")
+}
+print("")
+print("Cores: \(ProcessInfo.processInfo.activeProcessorCount). Checksum: \(checksum).")

--- a/BigInt.md
+++ b/BigInt.md
@@ -101,6 +101,10 @@ BigInt(1)  >> 100         //   0
 BigInt(1)  << -3          //   0       -- a negative count shifts the other way
 ```
 
+Worth knowing if you are porting off attaswift/BigInt, which shifts the magnitude
+and keeps the sign instead, so its `BigInt(-5) >> 1` is -2. `Int` floors, this
+floors; see [Benchmark.md](Benchmark.md).
+
 `~` on `BigUInt` is the one operator that cannot mean what it usually does: an
 unsigned value has no width to complement within, so it flips the bits the value
 currently occupies.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,20 @@ Then `import BigNum`. That is the only import you need — `BigInt` comes with i
 git clone https://github.com/dankogai/swift-bignum.git && cd swift-bignum && swift test
 ```
 
+### Benchmark
+
+`BigInt` is measured against [attaswift/BigInt] in [Benchmark.md](Benchmark.md) —
+faster as operands grow, slower at one or two limbs, and the two libraries turn
+out to disagree about `>>` on negative values. It runs only when asked:
+
+```bash
+cd Benchmarks && swift run -c release
+```
+
+That is a separate package on purpose. A benchmark target in this manifest would
+pull attaswift back in as a dependency of the root, and `swift build` would stop
+fetching nothing.
+
 ### Playground
 
 `macOS.playground` has a page per type — Synopsis, BigInt, BigRat, BigFloat,
@@ -221,6 +235,8 @@ the `BigNum` module is built, then open the playground.
   conformance, `IntRat` and the other fixed-width rationals
 * [BigFloat.md](BigFloat.md) — `BigFloat`: mantissa and scale, rounding,
   truncation, parsing
+* [Benchmark.md](Benchmark.md) — `BigInt` against attaswift/BigInt, and the one
+  place they disagree
 
 # Prerequisite
 
@@ -251,6 +267,11 @@ API attaswift gave them. Two deliberate breaks:
 * **`as*` conversions are now `to*()` methods** — `asDouble` became `toDouble()`,
   matching the `toString()` that was already there. Likewise `asBigRat`,
   `asMixed`, `asIntRat`, `asBigFloat`.
+
+And one difference that is not a break so much as a correction: **`>>` on a
+negative value floors**, as `Int` and `BinaryInteger` specify, where attaswift
+shifts the magnitude and keeps the sign. `BigInt(-5) >> 1` is -3 here and -2
+there. [Benchmark.md](Benchmark.md) has the comparison against `Int`.
 
 [attaswift/BigInt]: https://github.com/attaswift/BigInt
 [apple/swift-numerics]: https://github.com/apple/swift-numerics


### PR DESCRIPTION
Results in [Benchmark.md](Benchmark.md).

```bash
cd Benchmarks && swift run -c release
```

## It runs only when asked

`Benchmarks/` is a package of its own, not a target in this manifest. That is load-bearing rather than tidy: SwiftPM resolves every declared dependency whether or not the target using it is being built, so a benchmark target here would have pulled attaswift back in as a dependency of the root and ended the "`swift build` fetches nothing" property the last few PRs established.

Verified rather than assumed — the root manifest still declares no dependencies, `swift build` completes without fetching after `rm -rf .build/checkouts`, and `swift test` reports zero benchmark tests.

## The headline result is not a timing

**The two libraries disagree on `>>` for negative values, and attaswift is the one that departs from the standard library.** `BinaryInteger` specifies an arithmetic, flooring shift — what `Int` does, and what this package does. attaswift shifts the magnitude and keeps the sign, truncating toward zero:

| value | `Int` | swift-bignum | attaswift |
|---:|---:|---:|---:|
| -3 | -2 | -2 | **-1** |
| -5 | -3 | -3 | **-2** |
| -1025 | -513 | -513 | **-512** |

Across the seven values checked against `Int`, we match 7 and attaswift matches 3. This surfaced only because the harness checks agreement **before** timing anything: 4 of 75 cases disagreed, all of them this operation, and those rows report no ratio — timing two functions that compute different things is not a comparison. The benchmark regenerates that table itself, so the document does not rest on a one-off probe.

Recorded where someone porting would look: the README's migration list and BigInt.md beside the shift semantics.

## The timings

Asymptotics against a constant — we win as operands grow and lose at one or two limbs.

- `*` is 0.48× at 64 bits and 4.01× at 4096; `/` and `%` cross over likewise.
- Two's complement pays where it was supposed to: `+` at 1.5–2.3× and `&` on negatives at 1.7–2.1× at every size.
- `power(5)` reaches 9× at 1024 bits; `gcd` holds 1.6–2.9×.
- String conversion is the standing loss, 0.44–0.76×.

**Two results look fixable rather than inherent**, and Benchmark.md records them as leads, not as facts about the representation:

- `-` is written `lhs + (-rhs)` — two passes over the limbs and two allocations where one of each would do. It costs 2.3–2.5× our own `+` at every size, while attaswift's `-` is never slower than its `+`. It is the only arithmetic operation we lose at every size, and we win `+` everywhere, so it is leaving that on the table.
- Small operands carry a fixed per-call cost: `<< 61` takes 166 ns on one limb and 275 ns on 64 of them — a 64× larger input for 1.7× the time.

Neither is addressed here. This PR measures; changing `-` is a separate change with its own tests.

## Method

A benchmark is worth its method, so: both libraries parse the *same* hex string for each input; agreement is checked before timing; the iteration count scales until a batch takes 50 ms and the best of five batches is reported (best-of, because interference only makes batches slower); every result folds into a printed checksum so nothing measured is dead code; and the harness says so loudly if built without `-c release`, since a debug build measures the optimizer's absence rather than the algorithms. Run-to-run variation was under 5%, so Benchmark.md treats anything within 1.15× as noise.

Measured on an Apple M1, macOS 26.6.1, Swift 6.3.3, attaswift/BigInt 5.7.0.

## Two notes for the reviewer

`Benchmarks/Sources/Attaswift` is a two-line shim and an unavoidable one: attaswift's module and its main type are both named `BigInt`, and this package contains a class named `BigNum`, so in a file importing both neither `BigInt.BigInt` nor `BigNum.BigInt` resolves. SwiftPM's `moduleAliases` looked like the answer and is not. Inside a module importing only attaswift the bare name works and can be handed onward under one that does not collide — the same collision that made the old `@_exported import` necessary.

`Benchmarks/Package.resolved` is gitignored like the root one, so a later run may pick up a newer 5.x. Benchmark.md records the version measured and how to check which one you got.

🤖 Generated with [Claude Code](https://claude.com/claude-code)