### PR TITLE
Benchmark BigInt against JavaScript, Python and Ruby too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ fastlane/screenshots
 
 # Anything out of the sight of git
 .attic/
+
+# Benchmark output
+Benchmarks/.out/

--- a/Benchmark.md
+++ b/Benchmark.md
@@ -1,13 +1,15 @@
 # Benchmark
 
-`BigInt` here against [attaswift/BigInt], the dependency this package used to
-have. Same inputs, same machine, same run.
+`BigInt` here against [attaswift/BigInt] — the dependency this package used to
+have — and against the arbitrary-precision integers built into JavaScript,
+Python and Ruby. Same inputs, same machine, same run.
 
-**This is not part of `swift test`.** The benchmark is a package of its own, so
-running it is something you ask for:
+**None of this is part of `swift test`.** The benchmarks are a package of their
+own, so running them is something you ask for:
 
 ```bash
-cd Benchmarks && swift run -c release
+cd Benchmarks && swift run -c release      # against attaswift
+cd Benchmarks && sh cross/run.sh           # and against node, python, ruby
 ```
 
 It has to be its own package rather than a target in the root manifest, because
@@ -18,31 +20,205 @@ package.
 
 ## The one thing to read if you read nothing else
 
-**The two libraries disagree on `>>` for negative values, and attaswift is the
-one that departs from the standard library.** `Int` shifts arithmetically — it
-floors — and so does this package. attaswift shifts the magnitude and keeps the
-sign, which truncates toward zero:
+**Five implementations were asked to right-shift a negative number. Four agree,
+and the one that does not is attaswift.** `Int` shifts arithmetically — it floors
+— and so do this package, JavaScript, Python and Ruby. attaswift shifts the
+magnitude and keeps the sign, which truncates toward zero:
 
-| value | `Int` | swift-bignum | attaswift |
-|---:|---:|---:|---:|
-| -1 | -1 | -1 | -1 |
-| -2 | -1 | -1 | -1 |
-| -3 | -2 | -2 | -1 **differs** |
-| -5 | -3 | -3 | -2 **differs** |
-| -7 | -4 | -4 | -3 **differs** |
-| -8 | -4 | -4 | -4 |
-| -1025 | -513 | -513 | -512 **differs** |
-
-swift-bignum matches `Int` in 7 of 7 cases; attaswift in 3.
+| value | `Int` | swift-bignum | node | python | ruby | attaswift |
+|---:|---:|---:|---:|---:|---:|---:|
+| -1 | -1 | -1 | -1 | -1 | -1 | -1 |
+| -2 | -1 | -1 | -1 | -1 | -1 | -1 |
+| -3 | -2 | -2 | -2 | -2 | -2 | **-1** |
+| -5 | -3 | -3 | -3 | -3 | -3 | **-2** |
+| -7 | -4 | -4 | -4 | -4 | -4 | **-3** |
+| -8 | -4 | -4 | -4 | -4 | -4 | -4 |
+| -1025 | -513 | -513 | -513 | -513 | -513 | **-512** |
 
 `BinaryInteger` specifies the flooring behaviour, which is why this package
-matches `Int` exactly. If you are porting code off attaswift and it right-shifts
-negative numbers, the results will change — and they will change to the answers
-`Int` would have given. This is the only behavioural disagreement the benchmark
-found across 75 cases; the `>> (negative)` rows below are therefore marked `n/c`,
-since timing two functions that compute different things is not a comparison.
+matches `Int` exactly — and, as it turns out, matches every other language's
+bigint too. If you are porting code off attaswift and it right-shifts negative
+numbers, the results will change, and they will change to the answer everything
+else gives.
 
-## Where each one wins
+This was the only behavioural disagreement found anywhere: 75 cases against
+attaswift and 63 against the three languages, and this operation is the whole of
+it. The affected rows carry `n/c` rather than a ratio, because timing two
+functions that compute different things is not a comparison.
+
+## Against JavaScript, Python and Ruby
+
+Node's `BigInt`, CPython's `int` and Ruby's `Integer` are all C or C++
+implementations that have had far more attention than this package has, so the
+question is not whether they win but where and by how much.
+
+**Read the `baseline` row first.** It is the timing loop with no arithmetic in
+it, and in an interpreted language it is most of what a small operation costs:
+135 ns in Python and 153–249 ns in Ruby, against 11 ns in Swift and Node. A `†`
+marks any cell within 2× of its own harness's floor — those numbers are mostly
+the interpreter's loop, not its arithmetic, and they are excluded from the
+summary. At 64 bits nearly every Python and Ruby row carries one.
+
+All four implementations agree on every one of the 63 shared answers they were asked for, at every size.
+
+### 64 bits
+
+| operation | swift-bignum | node | python | ruby |
+|---|---:|---:|---:|---:|
+| `baseline` | 11 ns | 11 ns (0.93×) | 135 ns (**11.80×**) | 153 ns (**13.36×**) |
+| `+` | 77 ns | 22 ns (0.29×) | 153 ns (**1.99×**) † | 198 ns (**2.57×**) † |
+| `-` | 193 ns | 24 ns (0.13×) | 153 ns (0.79×) † | 154 ns (0.80×) † |
+| `*` | 233 ns | 24 ns (0.10×) | 174 ns (0.75×) † | 212 ns (0.91×) † |
+| `/` | 279 ns | 30 ns (0.11×) | 196 ns (0.70×) † | 260 ns (0.93×) † |
+| `%` | 280 ns | 30 ns (0.11×) | 195 ns (0.70×) † | 183 ns (0.66×) † |
+| `<` | 5 ns | 7 ns (**1.31×**) † | 74 ns (**14.56×**) † | 106 ns (**20.76×**) † |
+| `<< 61` | 167 ns | 24 ns (0.14×) | 154 ns (0.92×) † | 205 ns (**1.23×**) † |
+| `>> 61` | 166 ns | 24 ns (0.14×) | 155 ns (0.93×) † | 152 ns (0.92×) † |
+| `description` | 899 ns | 34 ns (0.04×) | 180 ns (0.20×) † | 199 ns (0.22×) † |
+| `init(radix: 10)` | 1.95 µs | 70 ns (0.04×) | 210 ns (0.11×) † | 235 ns (0.12×) † |
+| `init(radix: 16)` | 1.71 µs | 70 ns (0.04×) | 201 ns (0.12×) † | 229 ns (0.13×) † |
+| `squareRoot` | 140 ns | — | 188 ns (**1.35×**) † | 121 ns (0.87×) † |
+| `gcd` | 798 ns | — | 293 ns (0.37×) | 290 ns (0.36×) † |
+| `power(5)` | 1.61 µs | 78 ns (0.05×) | 444 ns (0.28×) | 330 ns (0.21×) |
+| `power(e, mod:)` | 100.11 µs | — | 13.16 µs (0.13×) | 13.66 µs (0.14×) |
+
+### 256 bits
+
+| operation | swift-bignum | node | python | ruby |
+|---|---:|---:|---:|---:|
+| `baseline` | 12 ns | 14 ns (**1.24×**) | 134 ns (**11.66×**) | 158 ns (**13.69×**) |
+| `+` | 79 ns | 25 ns (0.32×) † | 159 ns (**2.00×**) † | 207 ns (**2.61×**) † |
+| `-` | 197 ns | 36 ns (0.18×) | 166 ns (0.84×) † | 244 ns (**1.24×**) † |
+| `*` | 309 ns | 42 ns (0.13×) | 307 ns (0.99×) | 266 ns (0.86×) † |
+| `/` | 929 ns | 189 ns (0.20×) | 443 ns (0.48×) | 385 ns (0.41×) |
+| `%` | 902 ns | 191 ns (0.21×) | 442 ns (0.49×) | 353 ns (0.39×) |
+| `<` | 5 ns | 10 ns (**1.99×**) † | 81 ns (**16.17×**) † | 104 ns (**20.71×**) † |
+| `<< 61` | 169 ns | 28 ns (0.16×) † | 154 ns (0.91×) † | 209 ns (**1.23×**) † |
+| `>> 61` | 165 ns | 27 ns (0.16×) † | 157 ns (0.95×) † | 205 ns (**1.24×**) † |
+| `description` | 2.58 µs | 187 ns (0.07×) | 270 ns (0.10×) | 405 ns (0.16×) |
+| `init(radix: 10)` | 4.65 µs | 119 ns (0.03×) | 289 ns (0.06×) | 905 ns (0.19×) |
+| `init(radix: 16)` | 4.16 µs | 158 ns (0.04×) | 247 ns (0.06×) † | 393 ns (0.09×) |
+| `squareRoot` | 6.08 µs | — | 477 ns (0.08×) | 710 ns (0.12×) |
+| `gcd` | 2.97 µs | — | 942 ns (0.32×) | 6.09 µs (**2.05×**) |
+| `power(5)` | 1.66 µs | 204 ns (0.12×) | 1.39 µs (0.84×) | 775 ns (0.47×) |
+| `power(e, mod:)` | 920.19 µs | — | 466.28 µs (0.51×) | 342.30 µs (0.37×) |
+
+### 1024 bits
+
+| operation | swift-bignum | node | python | ruby |
+|---|---:|---:|---:|---:|
+| `baseline` | 11 ns | 14 ns (**1.28×**) | 133 ns (**11.86×**) | 174 ns (**15.45×**) |
+| `+` | 96 ns | 33 ns (0.35×) | 173 ns (**1.81×**) † | 241 ns (**2.52×**) † |
+| `-` | 227 ns | 35 ns (0.15×) | 171 ns (0.76×) † | 242 ns (**1.07×**) † |
+| `*` | 573 ns | 219 ns (0.38×) | 2.20 µs (**3.83×**) | 1.06 µs (**1.85×**) |
+| `/` | 2.47 µs | 905 ns (0.37×) | 2.90 µs (**1.17×**) | 2.41 µs (0.98×) |
+| `%` | 2.45 µs | 905 ns (0.37×) | 2.92 µs (**1.19×**) | 2.32 µs (0.94×) |
+| `<` | 5 ns | 7 ns (**1.48×**) † | 74 ns (**14.68×**) † | 106 ns (**20.96×**) † |
+| `<< 61` | 181 ns | 33 ns (0.18×) | 165 ns (0.91×) † | 235 ns (**1.30×**) † |
+| `>> 61` | 179 ns | 32 ns (0.18×) | 173 ns (0.97×) † | 228 ns (**1.28×**) † |
+| `description` | 9.39 µs | 1.46 µs (0.16×) | 1.47 µs (0.16×) | 1.99 µs (0.21×) |
+| `init(radix: 10)` | 16.54 µs | 551 ns (0.03×) | 1.14 µs (0.07×) | 6.45 µs (0.39×) |
+| `init(radix: 16)` | 15.06 µs | 361 ns (0.02×) | 457 ns (0.03×) | 1.04 µs (0.07×) |
+| `squareRoot` | 15.29 µs | — | 1.65 µs (0.11×) | 2.35 µs (0.15×) |
+| `gcd` | 28.99 µs | — | 3.76 µs (0.13×) | 44.44 µs (**1.53×**) |
+| `power(5)` | 4.57 µs | 1.78 µs (0.39×) | 11.15 µs (**2.44×**) | 9.21 µs (**2.02×**) |
+| `power(e, mod:)` | 25.15 ms | — | 16.33 ms (0.65×) | 17.78 ms (0.71×) |
+
+### 4096 bits
+
+| operation | swift-bignum | node | python | ruby |
+|---|---:|---:|---:|---:|
+| `baseline` | 11 ns | 14 ns (**1.20×**) | 136 ns (**11.92×**) | 249 ns (**21.76×**) |
+| `+` | 190 ns | 89 ns (0.47×) | 305 ns (**1.60×**) | 406 ns (**2.13×**) † |
+| `-` | 439 ns | 140 ns (0.32×) | 347 ns (0.79×) | 455 ns (**1.04×**) † |
+| `*` | 6.25 µs | 2.52 µs (0.40×) | 17.88 µs (**2.86×**) | 14.41 µs (**2.30×**) |
+| `/` | 16.47 µs | 8.22 µs (0.50×) | 37.71 µs (**2.29×**) | 30.10 µs (**1.83×**) |
+| `%` | 16.06 µs | 8.29 µs (0.52×) | 37.96 µs (**2.36×**) | 29.93 µs (**1.86×**) |
+| `<` | 5 ns | 10 ns (**1.92×**) † | 83 ns (**16.08×**) † | 102 ns (**19.82×**) † |
+| `<< 61` | 276 ns | 64 ns (0.23×) | 272 ns (0.98×) † | 365 ns (**1.32×**) † |
+| `>> 61` | 262 ns | 68 ns (0.26×) | 280 ns (**1.07×**) | 330 ns (**1.26×**) † |
+| `description` | 53.28 µs | 17.59 µs (0.33×) | 17.83 µs (0.33×) | 16.55 µs (0.31×) |
+| `init(radix: 10)` | 65.78 µs | 3.28 µs (0.05×) | 11.49 µs (0.17×) | 11.28 µs (0.17×) |
+| `init(radix: 16)` | 61.54 µs | 1.08 µs (0.02×) | 1.29 µs (0.02×) | 3.44 µs (0.06×) |
+| `squareRoot` | 92.03 µs | — | 12.30 µs (0.13×) | 11.67 µs (0.13×) |
+| `gcd` | 553.87 µs | — | 24.55 µs (0.04×) | 513.02 µs (0.93×) |
+| `power(5)` | 132.94 µs | 21.14 µs (0.16×) | 124.83 µs (0.94×) | 89.07 µs (0.67×) |
+
+### Summary
+
+Median of the per-operation ratios, over the operations all four have.
+Greater than 1 means swift-bignum was faster.
+
+| | 64 bits | 256 bits | 1024 bits | 4096 bits |
+|---|---:|---:|---:|---:|
+| node | 0.11× | 0.13× | 0.18× | 0.32× |
+| python | 0.28× | 0.49× | **1.17×** | **1.07×** |
+| ruby | 0.21× | 0.39× | 0.94× | 0.67× |
+
+Operations counted: those that clear 2× their own harness's `baseline` on both sides, out of `+`, `-`, `*`, `/`, `%`, `<`, `<< 61`, `>> 61`, `description`, `init(radix: 10)`, `init(radix: 16)`, `power(5)`. A † in the tables above marks a cell that does not, and is therefore mostly measuring the loop rather than the arithmetic.
+
+### What this says
+
+* **V8 wins nearly everything.** Node is 0.11×–0.52× at every size and every
+  operation except `<` and the `baseline` row itself. Its BigInt is a tuned C++
+  implementation with a fast path for small values, and the gap narrows as
+  operands grow — 0.11× median at 64 bits to 0.32× at 4096 — which is the same
+  asymptotic story as the attaswift comparison, told from further behind.
+* **Python and Ruby lose small, and win where the operands are large.** Both sit
+  at 0.2–0.5× below 1024 bits, where their interpreter loop dominates. Above that
+  the picture splits: Python's median crosses 1 (1.17× at 1024, 1.07× at 4096),
+  while Ruby's peaks at 0.94× and falls back to 0.67× — but both beat us
+  decisively on the two operations that dominate real bignum work. At 4096 bits
+  CPython is 2.86× our `*` and 2.29× our `/`; Ruby is 2.30× and 1.83×.
+* **Two gaps widen as the operands grow**, which is the signature of a
+  different algorithm rather than a slower constant. See below.
+
+### Where the gap widens with size, and where it is just a constant
+
+Whether a gap grows as the operands grow is the interesting question: a widening
+gap means a different algorithm, a flat one means a slower version of the same
+idea. Ratios of CPython's time to ours, below 1 meaning CPython is faster:
+
+| operation | 64 bits | 256 bits | 1024 bits | 4096 bits | |
+|---|---:|---:|---:|---:|---|
+| `init(radix: 16)` | 0.118 | 0.059 | 0.030 | 0.021 | widens |
+| `gcd` | 0.367 | 0.317 | 0.130 | 0.044 | widens |
+| `squareRoot` | 1.345 | 0.079 | 0.108 | 0.134 | flat |
+| `description` | 0.200 | 0.105 | 0.157 | 0.335 | flat |
+
+**Two of these are ours to fix, and the evidence is internal rather than
+comparative:**
+
+* **`init(radix: 16)` does work it does not need to.** At 4096 bits it costs
+  61.5 µs against 1.08 µs in Node and 1.29 µs in Python, and the gap widens by
+  nearly 6× from 64 bits to 4096 — the signature of quadratic against linear. The
+  telling comparison is with our own decimal parser: hex costs 61.5 µs and
+  decimal 65.8 µs, essentially the same. Decimal *has* to multiply. Hex does not,
+  since 16 is a power of two and its digits can be packed straight into limbs. We
+  run the same chunked multiply-and-add for both.
+* **`gcd` stops scaling.** 553.9 µs at 4096 bits against CPython's 24.6 µs, the
+  ratio falling from 0.37 to 0.04 as operands grow. Stein's binary GCD is a good
+  choice when small — it beats attaswift by 1.6–2.9× at every size — but each step
+  removes about one bit while touching every limb, so it is quadratic in the limb
+  count. The subquadratic methods work on the leading words and apply the result
+  to the whole number; a gap that widens like this is what points to one. Ruby, at
+  513 µs, sits beside us rather than beside CPython.
+
+**`squareRoot` and `description` are flat**, which makes them constant factors
+rather than wrong algorithms — roughly 8–12× on the square root above 256 bits and
+3–10× on decimal output, steady across sizes. Worth less than the two above.
+
+`power(e, mod:)` is the near miss: 25.2 ms against Python's 16.3 ms at 1024 bits,
+so 0.65×. Ours is square-and-multiply with a full reduction per exponent bit,
+which is the naive schedule; windowed exponentiation and Montgomery
+multiplication are the standard improvements, and neither is implemented here.
+
+None of this is addressed in this change. Measuring is one job; fixing is another,
+with its own tests.
+
+## Against attaswift/BigInt
+
+### Where each one wins
 
 Ratios are attaswift's time over ours, so **greater than 1 means swift-bignum is
 faster**. Anything within about 1.15× is noise (run-to-run variation on the same
@@ -90,7 +266,7 @@ Three groups stand out:
   bits. Chunking by the largest power of the radix that fits a limb was supposed
   to settle this and evidently does not; attaswift is simply better at it.
 
-## Two things this measured that look fixable
+### Two things this measured that look fixable
 
 Neither is a design consequence, so they are worth recording as leads rather than
 as facts about two's complement:
@@ -106,25 +282,45 @@ as facts about two's complement:
 
 ## Method
 
-* Both libraries parse the *same* hex string for each input, so neither is handed
-  a representation the other has to convert first.
+* All four implementations parse the *same* hex string for each input. The Swift
+  harness generates them and writes `.out/inputs.tsv`; Node, Python and Ruby read
+  that file rather than generating their own, so "same inputs" holds across
+  languages and not just across the two Swift libraries.
 * Every case is checked for agreement **before** it is timed, and disagreements
   are reported rather than averaged away. This is how the `>>` difference above
-  surfaced — it was not something either library documented.
+  surfaced — it was not something any implementation documented.
 * Iteration count scales until a batch takes 50 ms, then the best of five batches
   is reported. Best-of rather than mean, because interference can only make a
   batch slower.
-* Every result is folded into a checksum that gets printed, so nothing measured
-  is dead code.
+* Every result is folded into a checksum that gets printed, so nothing measured is
+  dead code. In JavaScript the operands are loop-invariant, which a JIT is free to
+  hoist; measured against a form that varies its operand per iteration, the
+  marginal cost of a 64-bit `*` was 8.5 ns invariant against 11.8 ns varying — a
+  1.4× difference rather than the ~10× that hoisting would show, so V8 is doing
+  the work.
+* Each harness measures its own `baseline` — the loop and the result-folding with
+  no arithmetic — and it is reported as a row rather than subtracted, because the
+  fold is not the same cost for every operation and a subtracted number would
+  imply a precision that is not there.
 * A debug build reports the absence of the optimizer rather than the algorithms,
-  so the harness says so loudly if it is built without `-c release`.
+  so the Swift harness says so loudly if it is built without `-c release`.
+
+Two things the numbers cannot tell you. The interpreted harnesses pay for their
+own loop on every iteration and the compiled one does not, so any row within a
+small multiple of its `baseline` is not a measurement of arithmetic. And Node,
+CPython and Ruby have no equivalent of the others' *language* overhead — a
+tight Swift loop over `BigInt` is not what code in those languages looks like, so
+these ratios are about the bignum implementations, not about the languages.
 
 Measured on an Apple M1 (8 cores), macOS 26.6.1, Swift 6.3.3, against
-attaswift/BigInt **5.7.0**. `Package.resolved` is not checked in, so a later run
-may pick up a newer 5.x — `swift package resolve && cat Package.resolved` in
-`Benchmarks/` says which version you actually got.
+attaswift/BigInt **5.7.0**, node **v24.18.0** (V8 13.6), CPython **3.9.6**, and
+Ruby **4.0.6** built `--without-gmp` — which matters, since a GMP-backed Ruby
+would be a different measurement entirely at the large sizes.
+`Package.resolved` is not checked in, so a later run may pick up a newer
+attaswift 5.x; `swift package resolve && cat Package.resolved` in `Benchmarks/`
+says which version you actually got.
 
-Absolute times, as generated:
+## Appendix: absolute times against attaswift
 
 | operation | bits | swift-bignum | attaswift | ratio |
 | `+` | 64 | 75 ns | 111 ns | **1.48×** |

--- a/Benchmarks/Sources/BigNumBenchmark/main.swift
+++ b/Benchmarks/Sources/BigNumBenchmark/main.swift
@@ -132,10 +132,16 @@ func bench(_ op: String, _ bits: Int,
 
 let sizes = [64, 256, 1024, 4096]
 
+/// The inputs, kept so they can be handed to the other languages' harnesses.
+/// Node, Python and Ruby read this file rather than generating their own, so
+/// "same inputs" holds across all four and not just across the two Swift ones.
+var sharedInputs: [(bits: Int, a: String, b: String, wide: String)] = []
+
 for bits in sizes {
     var rng = Random(seed: 0x5EED_0000 &+ UInt64(bits))
     let ha = rng.hex(bits: bits), hb = rng.hex(bits: bits)
     let hwide = rng.hex(bits: bits * 2)
+    sharedInputs.append((bits: bits, a: ha, b: hb, wide: hwide))
     let (oa, ob) = (Ours(ha, radix: 16)!, Ours(hb, radix: 16)!)
     let (ta, tb) = (Theirs(ha, radix: 16)!, Theirs(hb, radix: 16)!)
     let (owide, twide) = (Ours(hwide, radix: 16)!, Theirs(hwide, radix: 16)!)
@@ -145,6 +151,11 @@ for bits in sizes {
     let decimal = oa.description
     precondition(decimal == ta.description, "inputs differ at \(bits) bits")
 
+    // The floor: the timing loop and the fold, with no arithmetic in them.  Every
+    // other row sits on top of this, and in an interpreted language it is most of
+    // what a small operation costs.
+    bench("baseline", bits, same: { true },
+          ours: { fold(oa) }, theirs: { fold(ta) })
     bench("+", bits, same: { (oa + ob).description == (ta + tb).description },
           ours: { fold(oa + ob) }, theirs: { fold(ta + tb) })
     bench("-", bits, same: { (oa - ob).description == (ta - tb).description },
@@ -266,3 +277,69 @@ if !deviating.isEmpty {
 }
 print("")
 print("Cores: \(ProcessInfo.processInfo.activeProcessorCount). Checksum: \(checksum).")
+
+// MARK: - hand the inputs and the timings to the cross-language run
+//
+// Written unconditionally, so `cross/run.sh` can run this first and then give
+// Node, Python and Ruby exactly the same numbers to work on.
+
+let outDir = ".out"
+try? FileManager.default.createDirectory(atPath: outDir, withIntermediateDirectories: true)
+
+var inputLines = ["bits\ta\tb\twide"]
+for i in sharedInputs { inputLines.append("\(i.bits)\t\(i.a)\t\(i.b)\t\(i.wide)") }
+try? inputLines.joined(separator: "\n").appending("\n")
+      .write(toFile: "\(outDir)/inputs.tsv", atomically: true, encoding: .utf8)
+
+var resultLines = ["op\tbits\tns"]
+for r in results { resultLines.append("\(r.op)\t\(r.bits)\t\(r.ours)") }
+try? resultLines.joined(separator: "\n").appending("\n")
+      .write(toFile: "\(outDir)/results-swift.tsv", atomically: true, encoding: .utf8)
+
+// The answers, so the merge step can check that four independent implementations
+// computed the same thing before it prints a table comparing how fast they did.
+// Recomputed here rather than captured during timing, which keeps the timed
+// closures exactly as they were.
+var valueLines = ["op\tbits\tvalue"]
+for i in sharedInputs {
+    let a = Ours(i.a, radix: 16)!, b = Ours(i.b, radix: 16)!, wide = Ours(i.wide, radix: 16)!
+    let dec = a.description
+    func put(_ op: String, _ v: String) { valueLines.append("\(op)\t\(i.bits)\t\(v)") }
+    put("baseline", dec)
+    put("+", (a + b).description)
+    put("-", (a - b).description)
+    put("*", (a * b).description)
+    put("/", (wide / b).description)
+    put("%", (wide % b).description)
+    put("<", a < b ? "1" : "0")
+    put("<< 61", (a << 61).description)
+    put(">> 61", (a >> 61).description)
+    put("description", "\(dec.count)")
+    put("init(radix: 10)", Ours(dec)!.description)
+    put("init(radix: 16)", Ours(i.a, radix: 16)!.description)
+    put("squareRoot", a.squareRoot().description)
+    put("gcd", a.greatestCommonDivisor(with: b).description)
+    put("power(5)", a.power(5).description)
+    if i.bits <= 1024 { put("power(e, mod:)", a.power(b, mod: wide).description) }
+}
+try? valueLines.joined(separator: "\n").appending("\n")
+      .write(toFile: "\(outDir)/values-swift.tsv", atomically: true, encoding: .utf8)
+
+// `>> 1` on negatives, for the same table in every language.  attaswift is the
+// outlier among Swift libraries; this is where we find out whether it is an
+// outlier among languages too.
+var semanticLines = ["value\tshifted"]
+for v in [-1, -2, -3, -5, -7, -8, -1025] {
+    semanticLines.append("\(v)\t\(Ours(v) >> 1)")
+}
+try? semanticLines.joined(separator: "\n").appending("\n")
+      .write(toFile: "\(outDir)/semantics-swift.tsv", atomically: true, encoding: .utf8)
+var attaLines = ["value\tshifted"]
+for v in [-1, -2, -3, -5, -7, -8, -1025] {
+    attaLines.append("\(v)\t\(Theirs(v) >> 1)")
+}
+try? attaLines.joined(separator: "\n").appending("\n")
+      .write(toFile: "\(outDir)/semantics-attaswift.tsv", atomically: true, encoding: .utf8)
+
+FileHandle.standardError.write("\nwrote \(outDir)/inputs.tsv and \(outDir)/results-swift.tsv\n"
+                                 .data(using: .utf8)!)

--- a/Benchmarks/cross/bench.js
+++ b/Benchmarks/cross/bench.js
@@ -1,0 +1,95 @@
+//
+// The same operations, in JavaScript's BigInt, on the same inputs.
+//
+//     node cross/bench.js .out/inputs.tsv .out
+//
+// Method notes that matter for reading the numbers:
+//
+//  *  The loop body is timed as a whole, so per-op figures include one iteration
+//     of the interpreter's own loop.  The `baseline` row measures exactly that
+//     loop with no arithmetic in it, which is the floor everything else sits on.
+//  *  Each result is folded into an accumulator that gets printed, so V8 cannot
+//     drop the computation.  The operands are loop-invariant, which a JIT is in
+//     principle free to hoist; the `baseline` row is what would expose it, since
+//     a hoisted operation would come out at roughly that floor.
+//  *  V8 has no BigInt square root, gcd or modular exponentiation.  Those rows
+//     are absent rather than hand-written: timing a loop I wrote in JavaScript
+//     would measure my loop, not the runtime.
+//
+const fs = require('fs')
+
+const [inputPath, outDir] = [process.argv[2], process.argv[3]]
+const rows = fs.readFileSync(inputPath, 'utf8').trim().split('\n').slice(1)
+const inputs = rows.map(line => {
+  const [bits, a, b, wide] = line.split('\t')
+  return { bits: Number(bits), a: BigInt('0x' + a), b: BigInt('0x' + b),
+           wide: BigInt('0x' + wide), aHex: a }
+})
+
+let checksum = 0n
+
+function measure(body) {
+  let n = 1, elapsed = 0n
+  for (;;) {
+    const t0 = process.hrtime.bigint()
+    let acc = 0n
+    for (let i = 0; i < n; i++) acc ^= body()
+    elapsed = process.hrtime.bigint() - t0
+    checksum ^= acc
+    if (elapsed >= 50_000_000n || n >= (1 << 28)) break
+    n = elapsed < 1_000_000n ? n * 16 : n * 2
+  }
+  let best = Number(elapsed) / n
+  for (let round = 0; round < 4; round++) {
+    const t0 = process.hrtime.bigint()
+    let acc = 0n
+    for (let i = 0; i < n; i++) acc ^= body()
+    const each = Number(process.hrtime.bigint() - t0) / n
+    checksum ^= acc
+    best = Math.min(best, each)
+  }
+  return best
+}
+
+const results = []   // [op, bits, ns]
+const values = []    // [op, bits, decimal] -- for the cross-language agreement check
+
+function bench(op, bits, body, value) {
+  const ns = measure(body)
+  results.push([op, bits, ns])
+  values.push([op, bits, String(value)])
+  process.stderr.write(`  ${op.padEnd(18)} ${String(bits).padStart(5)} bits  ${ns.toFixed(1)} ns\n`)
+}
+
+// fold a BigInt result down to something cheap that still depends on all of it
+const fold = r => (r < 0n ? -r : r) & 0xffffn
+
+for (const { bits, a, b, wide, aHex } of inputs) {
+  const dec = a.toString()
+  bench('baseline', bits, () => fold(a), a)
+  bench('+', bits, () => fold(a + b), a + b)
+  bench('-', bits, () => fold(a - b), a - b)
+  bench('*', bits, () => fold(a * b), a * b)
+  bench('/', bits, () => fold(wide / b), wide / b)
+  bench('%', bits, () => fold(wide % b), wide % b)
+  bench('<', bits, () => (a < b ? 1n : 0n), a < b ? 1 : 0)
+  bench('<< 61', bits, () => fold(a << 61n), a << 61n)
+  bench('>> 61', bits, () => fold(a >> 61n), a >> 61n)
+  bench('description', bits, () => BigInt(a.toString().length), dec.length)
+  bench('init(radix: 10)', bits, () => fold(BigInt(dec)), BigInt(dec))
+  bench('init(radix: 16)', bits, () => fold(BigInt('0x' + aHex)), BigInt('0x' + aHex))
+  bench('power(5)', bits, () => fold(a ** 5n), a ** 5n)
+  // no squareRoot, gcd or power(e, mod:) in the language
+}
+
+// `>> 1` on negatives, the same table every harness emits
+const semantics = [-1, -2, -3, -5, -7, -8, -1025]
+      .map(v => [v, (BigInt(v) >> 1n).toString()])
+
+function write(name, rowsOut) {
+  fs.writeFileSync(`${outDir}/${name}`, rowsOut.map(r => r.join('\t')).join('\n') + '\n')
+}
+write('results-node.tsv', [['op', 'bits', 'ns'], ...results])
+write('values-node.tsv', [['op', 'bits', 'value'], ...values])
+write('semantics-node.tsv', [['value', 'shifted'], ...semantics])
+process.stderr.write(`\nnode ${process.version} (V8 ${process.versions.v8}). Checksum: ${checksum}\n`)

--- a/Benchmarks/cross/bench.py
+++ b/Benchmarks/cross/bench.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+#
+# The same operations, in CPython's int, on the same inputs.
+#
+#     python3 cross/bench.py .out/inputs.tsv .out
+#
+# See bench.js for the shared method notes.  Python has all of the operations,
+# `math.isqrt` and `math.gcd` and three-argument `pow` included, so nothing here
+# is hand-written.
+#
+# One semantic difference worth knowing, though it does not affect these numbers:
+# Python's `//` and `%` floor, where Swift's `/` and `%` truncate toward zero.
+# Every operand below is positive, where the two agree.
+#
+import math
+import sys
+import time
+
+input_path, out_dir = sys.argv[1], sys.argv[2]
+
+with open(input_path) as f:
+    rows = f.read().strip().split("\n")[1:]
+
+inputs = []
+for line in rows:
+    bits, a, b, wide = line.split("\t")
+    inputs.append((int(bits), int(a, 16), int(b, 16), int(wide, 16), a))
+
+checksum = 0
+
+
+def measure(body):
+    global checksum
+    n = 1
+    while True:
+        t0 = time.perf_counter_ns()
+        acc = 0
+        for _ in range(n):
+            acc ^= body()
+        elapsed = time.perf_counter_ns() - t0
+        checksum ^= acc
+        if elapsed >= 50_000_000 or n >= 1 << 28:
+            break
+        n = n * 16 if elapsed < 1_000_000 else n * 2
+    best = elapsed / n
+    for _ in range(4):
+        t0 = time.perf_counter_ns()
+        acc = 0
+        for _ in range(n):
+            acc ^= body()
+        each = (time.perf_counter_ns() - t0) / n
+        checksum ^= acc
+        best = min(best, each)
+    return best
+
+
+results = []
+values = []
+
+
+def bench(op, bits, body, value):
+    ns = measure(body)
+    results.append((op, bits, ns))
+    values.append((op, bits, str(value)))
+    sys.stderr.write("  %-18s %5d bits  %.1f ns\n" % (op, bits, ns))
+
+
+def fold(r):
+    return abs(r) & 0xFFFF
+
+
+for bits, a, b, wide, a_hex in inputs:
+    dec = str(a)
+    bench("baseline", bits, lambda: fold(a), a)
+    bench("+", bits, lambda: fold(a + b), a + b)
+    bench("-", bits, lambda: fold(a - b), a - b)
+    bench("*", bits, lambda: fold(a * b), a * b)
+    bench("/", bits, lambda: fold(wide // b), wide // b)
+    bench("%", bits, lambda: fold(wide % b), wide % b)
+    bench("<", bits, lambda: 1 if a < b else 0, 1 if a < b else 0)
+    bench("<< 61", bits, lambda: fold(a << 61), a << 61)
+    bench(">> 61", bits, lambda: fold(a >> 61), a >> 61)
+    bench("description", bits, lambda: len(str(a)), len(dec))
+    bench("init(radix: 10)", bits, lambda: fold(int(dec)), int(dec))
+    bench("init(radix: 16)", bits, lambda: fold(int(a_hex, 16)), int(a_hex, 16))
+    bench("squareRoot", bits, lambda: fold(math.isqrt(a)), math.isqrt(a))
+    bench("gcd", bits, lambda: fold(math.gcd(a, b)), math.gcd(a, b))
+    bench("power(5)", bits, lambda: fold(a ** 5), a ** 5)
+    if bits <= 1024:
+        bench("power(e, mod:)", bits, lambda: fold(pow(a, b, wide)), pow(a, b, wide))
+
+
+def write(name, header, rows_out):
+    with open("%s/%s" % (out_dir, name), "w") as f:
+        f.write("\t".join(header) + "\n")
+        for r in rows_out:
+            f.write("\t".join(str(x) for x in r) + "\n")
+
+
+semantics = [(v, v >> 1) for v in (-1, -2, -3, -5, -7, -8, -1025)]
+
+write("results-python.tsv", ("op", "bits", "ns"), results)
+write("values-python.tsv", ("op", "bits", "value"), values)
+write("semantics-python.tsv", ("value", "shifted"), semantics)
+sys.stderr.write("\n%s. Checksum: %d\n" % (sys.version.split()[0], checksum))

--- a/Benchmarks/cross/bench.rb
+++ b/Benchmarks/cross/bench.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+#
+# The same operations, in Ruby's Integer, on the same inputs.
+#
+#     ruby cross/bench.rb .out/inputs.tsv .out
+#
+# See bench.js for the shared method notes.  Ruby has all of the operations
+# natively: Integer.sqrt, Integer#gcd, and Integer#pow with a modulus.
+#
+# Whether Ruby's big integers are its own code or GMP's depends on how the
+# interpreter was built, and it changes the large-size numbers completely.  This
+# prints which one it got.
+#
+input_path, out_dir = ARGV[0], ARGV[1]
+
+inputs = File.read(input_path).strip.split("\n")[1..].map do |line|
+  bits, a, b, wide = line.split("\t")
+  [bits.to_i, a.to_i(16), b.to_i(16), wide.to_i(16), a]
+end
+
+$checksum = 0
+
+def measure
+  n = 1
+  elapsed = 0
+  loop do
+    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+    acc = 0
+    n.times { acc ^= yield }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0
+    $checksum ^= acc
+    break if elapsed >= 50_000_000 || n >= (1 << 28)
+    n = elapsed < 1_000_000 ? n * 16 : n * 2
+  end
+  best = elapsed.to_f / n
+  4.times do
+    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+    acc = 0
+    n.times { acc ^= yield }
+    each = (Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0).to_f / n
+    $checksum ^= acc
+    best = [best, each].min
+  end
+  best
+end
+
+results = []
+values = []
+
+def fold(r)
+  r.abs & 0xffff
+end
+
+def bench(results, values, op, bits, value)
+  ns = measure { yield }
+  results << [op, bits, ns]
+  values << [op, bits, value.to_s]
+  $stderr.printf("  %-18s %5d bits  %.1f ns\n", op, bits, ns)
+end
+
+inputs.each do |bits, a, b, wide, a_hex|
+  dec = a.to_s
+  bench(results, values, 'baseline', bits, a) { fold(a) }
+  bench(results, values, '+', bits, a + b) { fold(a + b) }
+  bench(results, values, '-', bits, a - b) { fold(a - b) }
+  bench(results, values, '*', bits, a * b) { fold(a * b) }
+  bench(results, values, '/', bits, wide / b) { fold(wide / b) }
+  bench(results, values, '%', bits, wide % b) { fold(wide % b) }
+  bench(results, values, '<', bits, a < b ? 1 : 0) { a < b ? 1 : 0 }
+  bench(results, values, '<< 61', bits, a << 61) { fold(a << 61) }
+  bench(results, values, '>> 61', bits, a >> 61) { fold(a >> 61) }
+  bench(results, values, 'description', bits, dec.length) { a.to_s.length }
+  bench(results, values, 'init(radix: 10)', bits, dec.to_i) { fold(dec.to_i) }
+  bench(results, values, 'init(radix: 16)', bits, a_hex.to_i(16)) { fold(a_hex.to_i(16)) }
+  bench(results, values, 'squareRoot', bits, Integer.sqrt(a)) { fold(Integer.sqrt(a)) }
+  bench(results, values, 'gcd', bits, a.gcd(b)) { fold(a.gcd(b)) }
+  bench(results, values, 'power(5)', bits, a**5) { fold(a**5) }
+  if bits <= 1024
+    bench(results, values, 'power(e, mod:)', bits, a.pow(b, wide)) { fold(a.pow(b, wide)) }
+  end
+end
+
+def write(out_dir, name, header, rows)
+  File.open("#{out_dir}/#{name}", 'w') do |f|
+    f.puts header.join("\t")
+    rows.each { |r| f.puts r.join("\t") }
+  end
+end
+
+semantics = [-1, -2, -3, -5, -7, -8, -1025].map { |v| [v, v >> 1] }
+
+write(out_dir, 'results-ruby.tsv', %w[op bits ns], results)
+write(out_dir, 'values-ruby.tsv', %w[op bits value], values)
+write(out_dir, 'semantics-ruby.tsv', %w[value shifted], semantics)
+gmp = RbConfig::CONFIG['configure_args'].to_s.include?('without-gmp') ? 'no GMP' : 'GMP possible'
+$stderr.puts "\nruby #{RUBY_VERSION} (#{gmp}). Checksum: #{$checksum}"

--- a/Benchmarks/cross/merge.py
+++ b/Benchmarks/cross/merge.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+#
+# Turn the four harnesses' output into the tables in Benchmark.md.
+#
+#     python3 cross/merge.py .out
+#
+# Agreement is checked before anything is formatted.  If two implementations
+# disagree about an answer, the row is marked and no ratio is printed for it --
+# comparing how fast two functions compute different things is not a comparison.
+#
+import os
+import sys
+
+out_dir = sys.argv[1] if len(sys.argv) > 1 else ".out"
+LANGS = ["swift", "node", "python", "ruby"]
+LABEL = {"swift": "swift-bignum", "node": "node", "python": "python", "ruby": "ruby"}
+SIZES = [64, 256, 1024, 4096]
+# the order they are reported in, which is the order they are run in
+OPS = ["baseline", "+", "-", "*", "/", "%", "<", "<< 61", ">> 61",
+       "description", "init(radix: 10)", "init(radix: 16)",
+       "squareRoot", "gcd", "power(5)", "power(e, mod:)"]
+
+
+def read(path):
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        rows = [line.rstrip("\n").split("\t") for line in f if line.strip()]
+    return rows[1:]
+
+
+times, values, semantics = {}, {}, {}
+for lang in LANGS:
+    r = read("%s/results-%s.tsv" % (out_dir, lang))
+    if r is None:
+        sys.exit("missing results for %s -- did its harness run?" % lang)
+    for op, bits, ns in r:
+        times[(lang, op, int(bits))] = float(ns)
+    for op, bits, value in read("%s/values-%s.tsv" % (out_dir, lang)) or []:
+        values[(lang, op, int(bits))] = value
+    semantics[lang] = read("%s/semantics-%s.tsv" % (out_dir, lang)) or []
+semantics["attaswift"] = read("%s/semantics-attaswift.tsv" % out_dir) or []
+
+
+# A row whose time is within this factor of its own harness overhead is mostly
+# measuring the harness.  Marked, and left out of the summary.
+FLOOR_FACTOR = 2.0
+
+
+def floor_of(lang, bits):
+    return times.get((lang, "baseline", bits), 0.0)
+
+
+def above_floor(lang, op, bits):
+    t = times.get((lang, op, bits))
+    f = floor_of(lang, bits)
+    return t is not None and (f == 0.0 or t >= FLOOR_FACTOR * f)
+
+
+def fmt(ns):
+    if ns < 1000:
+        return "%.0f ns" % ns
+    if ns < 1_000_000:
+        return "%.2f µs" % (ns / 1000)
+    return "%.2f ms" % (ns / 1_000_000)
+
+
+# ---- agreement, first and before any timing is shown
+disagreements = []
+for op in OPS:
+    for bits in SIZES:
+        present = {l: values.get((l, op, bits)) for l in LANGS
+                   if (l, op, bits) in values}
+        if len(present) < 2:
+            continue
+        distinct = set(present.values())
+        if len(distinct) > 1:
+            disagreements.append((op, bits, present))
+
+print("## Against JavaScript, Python and Ruby")
+print()
+checked = sum(1 for op in OPS for bits in SIZES
+              if sum(1 for l in LANGS if (l, op, bits) in values) >= 2)
+if disagreements:
+    print("**%d of %d shared answers disagree.**" % (len(disagreements), checked))
+    print()
+    for op, bits, present in disagreements:
+        print("* `%s` at %d bits: " % (op, bits)
+              + ", ".join("%s → `%s`" % (LABEL[l], v[:40]) for l, v in present.items()))
+    print()
+else:
+    print("All four implementations agree on every one of the %d shared answers "
+          "they were asked for, at every size." % checked)
+    print()
+
+# ---- one table per size
+for bits in SIZES:
+    print("### %d bits" % bits)
+    print()
+    print("| operation | swift-bignum | node | python | ruby |")
+    print("|---|---:|---:|---:|---:|")
+    for op in OPS:
+        if ("swift", op, bits) not in times:
+            continue
+        base = times[("swift", op, bits)]
+        cells = [fmt(base)]
+        for lang in ["node", "python", "ruby"]:
+            t = times.get((lang, op, bits))
+            if t is None:
+                cells.append("—")
+                continue
+            ratio = t / base
+            bad = any(d[0] == op and d[1] == bits for d in disagreements)
+            mark = "" if above_floor(lang, op, bits) or op == "baseline" else " †"
+            if bad:
+                cells.append("%s (n/c)%s" % (fmt(t), mark))
+            elif ratio >= 1:
+                cells.append("%s (**%.2f×**)%s" % (fmt(t), ratio, mark))
+            else:
+                cells.append("%s (%.2f×)%s" % (fmt(t), ratio, mark))
+        print("| `%s` | %s |" % (op, " | ".join(cells)))
+    print()
+
+# ---- summary: the median ratio per language per size, over the shared ops
+print("### Summary")
+print()
+print("Median of the per-operation ratios, over the operations all four have.")
+print("Greater than 1 means swift-bignum was faster.")
+print()
+shared = [op for op in OPS
+          if all((l, op, 64) in times for l in LANGS) and op != "baseline"]
+print("| | " + " | ".join("%d bits" % b for b in SIZES) + " |")
+print("|---|" + "---:|" * len(SIZES))
+for lang in ["node", "python", "ruby"]:
+    cells = []
+    for bits in SIZES:
+        rs = sorted(times[(lang, op, bits)] / times[("swift", op, bits)]
+                    for op in shared
+                    if (lang, op, bits) in times and ("swift", op, bits) in times
+                    and above_floor(lang, op, bits) and above_floor("swift", op, bits))
+        if not rs:
+            cells.append("—")
+        else:
+            m = rs[len(rs) // 2]
+            cells.append("**%.2f×**" % m if m >= 1 else "%.2f×" % m)
+    print("| %s | %s |" % (LABEL[lang], " | ".join(cells)))
+print()
+print("Operations counted: those that clear %.0f× their own harness's `baseline` on "
+      "both sides, out of %s. A † in the tables above marks a cell that does not, "
+      "and is therefore mostly measuring the loop rather than the arithmetic."
+      % (FLOOR_FACTOR, ", ".join("`%s`" % o for o in shared)))
+print()
+
+# ---- the negative-shift table, now with three more implementations in it
+print("### `>> 1` on negative values, across five implementations")
+print()
+have = [l for l in ["swift", "node", "python", "ruby", "attaswift"] if semantics.get(l)]
+print("| value | " + " | ".join(LABEL.get(l, l) for l in have) + " |")
+print("|---:|" + "---:|" * len(have))
+rows = {l: dict(semantics[l]) for l in have}
+for v, _ in semantics["swift"]:
+    cells = []
+    for l in have:
+        got = rows[l].get(v, "?")
+        cells.append(got if got == rows["python"].get(v) else "**%s**" % got)
+    print("| %s | %s |" % (v, " | ".join(cells)))
+print()
+odd = [l for l in have if rows[l] != rows["python"]]
+print("Agreeing: " + ", ".join(LABEL.get(l, l) for l in have if l not in odd)
+      + (". Differing: " + ", ".join(LABEL.get(l, l) for l in odd) + "." if odd else "."))

--- a/Benchmarks/cross/run.sh
+++ b/Benchmarks/cross/run.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# swift-bignum's BigInt against JavaScript, Python and Ruby.
+#
+#     cd Benchmarks && sh cross/run.sh
+#
+# The Swift harness runs first because it is the one that generates the inputs:
+# it writes .out/inputs.tsv, and the other three read it, so all four are handed
+# identical numbers to work on rather than each making up its own.
+#
+# Everything lands in .out/ (gitignored).  The tables for Benchmark.md go to
+# stdout; progress goes to stderr, so `sh cross/run.sh > tables.md` gives you
+# just the tables.
+#
+# Takes a few minutes.  Most of it is the modular exponentiation at 1024 bits,
+# where one call is tens of milliseconds in every language.
+#
+set -e
+cd "$(dirname "$0")/.."
+mkdir -p .out
+
+missing=""
+for tool in node python3 ruby; do
+    command -v "$tool" > /dev/null 2>&1 || missing="$missing $tool"
+done
+if [ -n "$missing" ]; then
+    echo "not found:$missing -- install them, or run the harnesses you have by hand" >&2
+    exit 1
+fi
+
+echo "=== swift-bignum (release), which also writes the shared inputs" >&2
+swift run -c release > .out/swift-vs-attaswift.md
+
+echo "=== node" >&2
+node    cross/bench.js .out/inputs.tsv .out
+echo "=== python" >&2
+python3 cross/bench.py .out/inputs.tsv .out
+echo "=== ruby" >&2
+ruby    cross/bench.rb .out/inputs.tsv .out
+
+echo "=== merging" >&2
+python3 cross/merge.py .out

--- a/README.md
+++ b/README.md
@@ -209,13 +209,20 @@ git clone https://github.com/dankogai/swift-bignum.git && cd swift-bignum && swi
 
 ### Benchmark
 
-`BigInt` is measured against [attaswift/BigInt] in [Benchmark.md](Benchmark.md) —
-faster as operands grow, slower at one or two limbs, and the two libraries turn
-out to disagree about `>>` on negative values. It runs only when asked:
+[Benchmark.md](Benchmark.md) measures `BigInt` against [attaswift/BigInt] and
+against the bigints built into JavaScript, Python and Ruby. Both run only when
+asked:
 
 ```bash
-cd Benchmarks && swift run -c release
+cd Benchmarks && swift run -c release      # against attaswift
+cd Benchmarks && sh cross/run.sh           # and against node, python, ruby
 ```
+
+Briefly: faster than attaswift as operands grow and slower at one or two limbs;
+comfortably behind V8's `BigInt` everywhere; ahead of CPython and Ruby below 1024
+bits and behind them on multiplication and division above it. Five
+implementations were asked to right-shift a negative number and attaswift is the
+only one that answers differently.
 
 That is a separate package on purpose. A benchmark target in this manifest would
 pull attaswift back in as a dependency of the root, and `swift build` would stop
@@ -235,8 +242,8 @@ the `BigNum` module is built, then open the playground.
   conformance, `IntRat` and the other fixed-width rationals
 * [BigFloat.md](BigFloat.md) — `BigFloat`: mantissa and scale, rounding,
   truncation, parsing
-* [Benchmark.md](Benchmark.md) — `BigInt` against attaswift/BigInt, and the one
-  place they disagree
+* [Benchmark.md](Benchmark.md) — `BigInt` against attaswift/BigInt, JavaScript,
+  Python and Ruby, and the one place any of them disagree
 
 # Prerequisite
 


### PR DESCRIPTION
```bash
cd Benchmarks && sh cross/run.sh
```

Node, CPython and Ruby harnesses beside the existing attaswift one, sharing its inputs and its method. Results in [Benchmark.md](Benchmark.md). Bitwise operators are left out as asked; shifts are kept, since every language has them and they turn out to matter.

The Swift harness now writes `.out/inputs.tsv` and the other three read it, so **"same inputs" holds across languages** rather than each generating its own. It also writes its timings and its answers, so the merge step builds the tables from data instead of from me retyping numbers.

**All 63 shared answers agree** across the four implementations.

## Two method problems that had to be fixed first

**Python spends 135 ns per iteration in its own interpreter loop** — Ruby 153–249 ns, against ~11 ns in Swift and Node. At 64 bits that is most of what a Python "operation" costs, so a raw per-op comparison there pits Swift arithmetic against Python arithmetic *plus* bytecode dispatch. Every harness now measures a `baseline` — the loop and the result-folding with no arithmetic in it — reported as a row rather than subtracted, because the fold is not the same cost for every operation and a subtracted figure would imply precision that is not there. A `†` marks any cell within 2× of its own floor, and those are excluded from the summary; at 64 bits nearly every Python and Ruby row carries one. The Swift harness gained a `baseline` case too, so all four are calibrated identically.

**Node's 24 ns BigInt multiply looked too fast to be real**, and a loop-invariant operand is something a JIT may hoist out of a timing loop entirely. Measured against a form whose operand changes every iteration: marginal cost 8.5 ns invariant against 11.8 ns varying — 1.4×, not the ~10× hoisting would show. V8 is doing the work.

## Results

| | 64 bits | 256 | 1024 | 4096 |
|---|---:|---:|---:|---:|
| node | 0.11× | 0.13× | 0.18× | 0.32× |
| python | 0.28× | 0.49× | **1.17×** | **1.07×** |
| ruby | 0.21× | 0.39× | 0.94× | 0.67× |

V8 wins nearly everything (0.11×–0.52× at every size and operation but `<`). Python and Ruby lose below 1024 bits and beat us on multiplication and division above it — CPython 2.86× on `*` and 2.29× on `/` at 4096 bits.

## The part worth acting on

Whether a gap *widens* with operand size is the interesting question: widening means a different algorithm, flat means a slower version of the same idea.

| operation | 64 | 256 | 1024 | 4096 | |
|---|---:|---:|---:|---:|---|
| `init(radix: 16)` | 0.118 | 0.059 | 0.030 | 0.021 | widens |
| `gcd` | 0.367 | 0.317 | 0.130 | 0.044 | widens |
| `squareRoot` | 1.345 | 0.079 | 0.108 | 0.134 | flat |
| `description` | 0.200 | 0.105 | 0.157 | 0.335 | flat |

- **`init(radix: 16)`** — the evidence that the fault is ours is internal rather than comparative: our hex parse costs 61.5 µs and our *decimal* parse 65.8 µs, essentially the same. Decimal has to multiply; hex does not, since 16 is a power of two and its digits can be packed straight into limbs. We run the same chunked multiply-and-add for both.
- **`gcd`** — 22× slower than CPython at 4096 bits, which is what a binary GCD that removes about one bit per pass over every limb costs.
- **`squareRoot` and `description` are flat**, so constant factors rather than wrong algorithms, and worth less.

Nothing here is fixed. Measuring is one job; fixing is another, with its own tests.

## The `>>` finding got stronger

**JavaScript, Python and Ruby all agree with `Int` and with this package, and attaswift is the sole outlier among five implementations.** That table is promoted to the top of Benchmark.md. The benchmark regenerates it, so it does not rest on a one-off probe.

## Two claims I corrected in my own draft

- I wrote that Python and Ruby both win at large sizes. Only Python's median crosses 1 — Ruby peaks at 0.94× and falls back to 0.67×.
- I attributed specific algorithms to CPython (Lehmer's GCD, an adaptive-precision `isqrt`) that I had not verified. Those passages now describe the measured scaling instead of someone else's source.

## Unchanged

Root manifest still declares no dependencies; `swift build` fetches nothing; `swift test` is 73 tests in 8 suites, untouched. `.out/` is gitignored, so no generated output is in the diff.

Ruby is built `--without-gmp` here, which matters — a GMP-backed Ruby would be a different measurement at the large sizes, and Benchmark.md says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)