### PR TITLE
Act on the benchmark: radix conversion, subtraction, small multiply and gcd

### DIFF
--- a/Benchmark.md
+++ b/Benchmark.md
@@ -12,6 +12,10 @@ cd Benchmarks && swift run -c release      # against attaswift
 cd Benchmarks && sh cross/run.sh           # and against node, python, ruby
 ```
 
+The cross-language run uses `/usr/bin/ruby`, the one macOS ships, since that is
+the Ruby a Mac has without being asked. `RUBY=/path/to/ruby sh cross/run.sh`
+picks another; a newer Ruby measures noticeably differently.
+
 It has to be its own package rather than a target in the root manifest, because
 SwiftPM resolves every declared dependency whether or not the target using it is
 being built — a benchmark target at the root would quietly end the "`swift build`
@@ -41,23 +45,67 @@ bigint too. If you are porting code off attaswift and it right-shifts negative
 numbers, the results will change, and they will change to the answer everything
 else gives.
 
-This was the only behavioural disagreement found anywhere: 75 cases against
-attaswift and 63 against the three languages, and this operation is the whole of
-it. The affected rows carry `n/c` rather than a ratio, because timing two
-functions that compute different things is not a comparison.
+This is the only behavioural disagreement found anywhere: 75 cases against
+attaswift and 63 against the three languages. The affected rows carry `n/c`
+rather than a ratio, because timing two functions that compute different things
+is not a comparison.
+
+## What benchmarking changed
+
+The first run of this benchmark found five things worth fixing, and they are
+fixed. Speedups of the current code over the code that was measured:
+
+| operation | 64 bits | 256 bits | 1024 bits | 4096 bits |
+|---|---:|---:|---:|---:|
+| `init(radix: 16)` | **9.4×** | **16.2×** | **26.2×** | **33.1×** |
+| `init(radix: 10)` | **11.6×** | **18.8×** | **25.9×** | **20.5×** |
+| `description` | **2.4×** | **5.4×** | **5.1×** | **2.1×** |
+| `-` | **2.5×** | **2.4×** | **2.4×** | **2.2×** |
+| `*` | **4.3×** | 1.02× | 0.99× | 1.05× |
+| `gcd` | **6.6×** | 0.94× | 1.12× | 0.97× |
+| `<< 61` | 1.03× | 1.02× | 1.07× | 1.25× |
+| `>> 61` | 1.04× | 1.02× | 1.13× | **1.5×** |
+| `+` | 1.02× | 1.00× | 1.00× | 1.00× |
+| `/` | 1.02× | 1.02× | 1.00× | 1.01× |
+| `squareRoot` | 1.01× | 1.01× | 1.03× | 0.98× |
+| `power(5)` | 1.24× | 1.06× | 1.02× | 1.04× |
+
+* **Radix conversion was the big one.** Powers of two need no arithmetic at all —
+  16 is four bits, so a hex digit *is* half a limb — but the parser ran the same
+  chunked multiply-and-add it uses for decimal. The giveaway was internal rather
+  than comparative: hex cost the same as decimal, when decimal has to multiply
+  and hex does not. Both directions now special-case radix 2, 4, 8, 16 and 32
+  ([Radix.swift](Sources/BigNum/Radix.swift)), and every other radix runs the
+  chunked algorithm on the limbs in place, one allocation instead of one per
+  chunk.
+* **`-` was `lhs + (-rhs)`** — three passes and three allocations where two's
+  complement subtraction is `lhs + ~rhs + 1` in one of each.
+* **`*` and `gcd` had no small-operand path.** Limb *count* was the wrong test: a
+  positive value with its top bit set carries a clear sign limb, so 2^63 is two
+  limbs wide while its magnitude is one. Testing the magnitude instead
+  (`singleLimbMagnitude`) puts every `Int`-sized pair through
+  `multipliedFullWidth` and a word-sized binary GCD, in registers.
+* **`description` built a `String` per digit chunk** and concatenated them. It now
+  writes one byte buffer, with radix 10 getting its own copy of the digit loop so
+  that the divisor is a literal the compiler can turn into a multiply.
+
+Two things I tried that were not worth it, recorded so nobody repeats them: the
+shift primitives had four branches per limb in their inner loops, and hoisting
+those out bought 1.0–1.5× — the cost is the allocation, not the loop. Same for
+the radix-10 digit specialisation, which moved `description` at 64 bits by about
+5%. Every gain above of any size came from removing an allocation or an
+algorithm, never from tightening a loop.
 
 ## Against JavaScript, Python and Ruby
 
 Node's `BigInt`, CPython's `int` and Ruby's `Integer` are all C or C++
-implementations that have had far more attention than this package has, so the
-question is not whether they win but where and by how much.
+implementations with far more attention behind them than this package has.
 
 **Read the `baseline` row first.** It is the timing loop with no arithmetic in
 it, and in an interpreted language it is most of what a small operation costs:
-135 ns in Python and 153–249 ns in Ruby, against 11 ns in Swift and Node. A `†`
-marks any cell within 2× of its own harness's floor — those numbers are mostly
-the interpreter's loop, not its arithmetic, and they are excluded from the
-summary. At 64 bits nearly every Python and Ruby row carries one.
+134 ns in Python and 121 ns in Ruby, against 11 ns in Swift and Node. A `†` marks
+any cell within 2× of its own harness's floor — those are mostly the
+interpreter's loop, not its arithmetic, and they are excluded from the summary.
 
 All four implementations agree on every one of the 63 shared answers they were asked for, at every size.
 
@@ -65,84 +113,84 @@ All four implementations agree on every one of the 63 shared answers they were a
 
 | operation | swift-bignum | node | python | ruby |
 |---|---:|---:|---:|---:|
-| `baseline` | 11 ns | 11 ns (0.93×) | 135 ns (**11.80×**) | 153 ns (**13.36×**) |
-| `+` | 77 ns | 22 ns (0.29×) | 153 ns (**1.99×**) † | 198 ns (**2.57×**) † |
-| `-` | 193 ns | 24 ns (0.13×) | 153 ns (0.79×) † | 154 ns (0.80×) † |
-| `*` | 233 ns | 24 ns (0.10×) | 174 ns (0.75×) † | 212 ns (0.91×) † |
-| `/` | 279 ns | 30 ns (0.11×) | 196 ns (0.70×) † | 260 ns (0.93×) † |
-| `%` | 280 ns | 30 ns (0.11×) | 195 ns (0.70×) † | 183 ns (0.66×) † |
-| `<` | 5 ns | 7 ns (**1.31×**) † | 74 ns (**14.56×**) † | 106 ns (**20.76×**) † |
-| `<< 61` | 167 ns | 24 ns (0.14×) | 154 ns (0.92×) † | 205 ns (**1.23×**) † |
-| `>> 61` | 166 ns | 24 ns (0.14×) | 155 ns (0.93×) † | 152 ns (0.92×) † |
-| `description` | 899 ns | 34 ns (0.04×) | 180 ns (0.20×) † | 199 ns (0.22×) † |
-| `init(radix: 10)` | 1.95 µs | 70 ns (0.04×) | 210 ns (0.11×) † | 235 ns (0.12×) † |
-| `init(radix: 16)` | 1.71 µs | 70 ns (0.04×) | 201 ns (0.12×) † | 229 ns (0.13×) † |
-| `squareRoot` | 140 ns | — | 188 ns (**1.35×**) † | 121 ns (0.87×) † |
-| `gcd` | 798 ns | — | 293 ns (0.37×) | 290 ns (0.36×) † |
-| `power(5)` | 1.61 µs | 78 ns (0.05×) | 444 ns (0.28×) | 330 ns (0.21×) |
-| `power(e, mod:)` | 100.11 µs | — | 13.16 µs (0.13×) | 13.66 µs (0.14×) |
+| `baseline` | 11 ns | 11 ns (0.93×) | 134 ns (**11.74×**) | 121 ns (**10.58×**) |
+| `+` | 75 ns | 22 ns (0.30×) | 153 ns (**2.02×**) † | 143 ns (**1.90×**) † |
+| `-` | 78 ns | 25 ns (0.32×) | 152 ns (**1.96×**) † | 117 ns (**1.51×**) † |
+| `*` | 54 ns | 26 ns (0.47×) | 174 ns (**3.22×**) † | 157 ns (**2.92×**) † |
+| `/` | 275 ns | 31 ns (0.11×) | 195 ns (0.71×) † | 218 ns (0.79×) † |
+| `%` | 274 ns | 31 ns (0.11×) | 196 ns (0.71×) † | 170 ns (0.62×) † |
+| `<` | 5 ns | 7 ns (**1.36×**) † | 74 ns (**14.64×**) † | 71 ns (**13.92×**) † |
+| `<< 61` | 161 ns | 25 ns (0.15×) | 153 ns (0.95×) † | 152 ns (0.94×) † |
+| `>> 61` | 160 ns | 24 ns (0.15×) | 156 ns (0.97×) † | 122 ns (0.76×) † |
+| `description` | 375 ns | 35 ns (0.09×) | 179 ns (0.48×) † | 200 ns (0.53×) † |
+| `init(radix: 10)` | 168 ns | 72 ns (0.43×) | 209 ns (**1.25×**) † | 191 ns (**1.14×**) † |
+| `init(radix: 16)` | 181 ns | 70 ns (0.39×) | 200 ns (**1.11×**) † | 187 ns (**1.03×**) † |
+| `squareRoot` | 139 ns | — | 189 ns (**1.36×**) † | 107 ns (0.77×) † |
+| `gcd` | 121 ns | — | 291 ns (**2.41×**) | 235 ns (**1.95×**) † |
+| `power(5)` | 1.29 µs | 78 ns (0.06×) | 447 ns (0.35×) | 549 ns (0.43×) |
+| `power(e, mod:)` | 99.42 µs | — | 13.10 µs (0.13×) | 24.36 µs (0.25×) |
 
 ### 256 bits
 
 | operation | swift-bignum | node | python | ruby |
 |---|---:|---:|---:|---:|
-| `baseline` | 12 ns | 14 ns (**1.24×**) | 134 ns (**11.66×**) | 158 ns (**13.69×**) |
-| `+` | 79 ns | 25 ns (0.32×) † | 159 ns (**2.00×**) † | 207 ns (**2.61×**) † |
-| `-` | 197 ns | 36 ns (0.18×) | 166 ns (0.84×) † | 244 ns (**1.24×**) † |
-| `*` | 309 ns | 42 ns (0.13×) | 307 ns (0.99×) | 266 ns (0.86×) † |
-| `/` | 929 ns | 189 ns (0.20×) | 443 ns (0.48×) | 385 ns (0.41×) |
-| `%` | 902 ns | 191 ns (0.21×) | 442 ns (0.49×) | 353 ns (0.39×) |
-| `<` | 5 ns | 10 ns (**1.99×**) † | 81 ns (**16.17×**) † | 104 ns (**20.71×**) † |
-| `<< 61` | 169 ns | 28 ns (0.16×) † | 154 ns (0.91×) † | 209 ns (**1.23×**) † |
-| `>> 61` | 165 ns | 27 ns (0.16×) † | 157 ns (0.95×) † | 205 ns (**1.24×**) † |
-| `description` | 2.58 µs | 187 ns (0.07×) | 270 ns (0.10×) | 405 ns (0.16×) |
-| `init(radix: 10)` | 4.65 µs | 119 ns (0.03×) | 289 ns (0.06×) | 905 ns (0.19×) |
-| `init(radix: 16)` | 4.16 µs | 158 ns (0.04×) | 247 ns (0.06×) † | 393 ns (0.09×) |
-| `squareRoot` | 6.08 µs | — | 477 ns (0.08×) | 710 ns (0.12×) |
-| `gcd` | 2.97 µs | — | 942 ns (0.32×) | 6.09 µs (**2.05×**) |
-| `power(5)` | 1.66 µs | 204 ns (0.12×) | 1.39 µs (0.84×) | 775 ns (0.47×) |
-| `power(e, mod:)` | 920.19 µs | — | 466.28 µs (0.51×) | 342.30 µs (0.37×) |
+| `baseline` | 11 ns | 14 ns (**1.24×**) | 135 ns (**11.84×**) | 186 ns (**16.27×**) |
+| `+` | 79 ns | 25 ns (0.32×) † | 157 ns (**1.98×**) † | 314 ns (**3.97×**) † |
+| `-` | 82 ns | 36 ns (0.44×) | 166 ns (**2.03×**) † | 393 ns (**4.81×**) |
+| `*` | 304 ns | 43 ns (0.14×) | 304 ns (**1.00×**) | 391 ns (**1.29×**) |
+| `/` | 911 ns | 184 ns (0.20×) | 437 ns (0.48×) | 610 ns (0.67×) |
+| `%` | 933 ns | 186 ns (0.20×) | 435 ns (0.47×) | 482 ns (0.52×) |
+| `<` | 5 ns | 10 ns (**1.91×**) † | 81 ns (**15.67×**) † | 70 ns (**13.70×**) † |
+| `<< 61` | 166 ns | 28 ns (0.17×) † | 154 ns (0.93×) † | 327 ns (**1.97×**) † |
+| `>> 61` | 162 ns | 27 ns (0.16×) † | 158 ns (0.97×) † | 321 ns (**1.97×**) † |
+| `description` | 482 ns | 186 ns (0.39×) | 273 ns (0.57×) | 475 ns (0.98×) |
+| `init(radix: 10)` | 247 ns | 119 ns (0.48×) | 289 ns (**1.17×**) | 1.03 µs (**4.15×**) |
+| `init(radix: 16)` | 257 ns | 155 ns (0.60×) | 250 ns (0.97×) † | 536 ns (**2.08×**) |
+| `squareRoot` | 6.04 µs | — | 478 ns (0.08×) | 792 ns (0.13×) |
+| `gcd` | 3.17 µs | — | 951 ns (0.30×) | 10.65 µs (**3.36×**) |
+| `power(5)` | 1.56 µs | 198 ns (0.13×) | 1.41 µs (0.90×) | 1.06 µs (0.68×) |
+| `power(e, mod:)` | 917.91 µs | — | 468.58 µs (0.51×) | 459.23 µs (0.50×) |
 
 ### 1024 bits
 
 | operation | swift-bignum | node | python | ruby |
 |---|---:|---:|---:|---:|
-| `baseline` | 11 ns | 14 ns (**1.28×**) | 133 ns (**11.86×**) | 174 ns (**15.45×**) |
-| `+` | 96 ns | 33 ns (0.35×) | 173 ns (**1.81×**) † | 241 ns (**2.52×**) † |
-| `-` | 227 ns | 35 ns (0.15×) | 171 ns (0.76×) † | 242 ns (**1.07×**) † |
-| `*` | 573 ns | 219 ns (0.38×) | 2.20 µs (**3.83×**) | 1.06 µs (**1.85×**) |
-| `/` | 2.47 µs | 905 ns (0.37×) | 2.90 µs (**1.17×**) | 2.41 µs (0.98×) |
-| `%` | 2.45 µs | 905 ns (0.37×) | 2.92 µs (**1.19×**) | 2.32 µs (0.94×) |
-| `<` | 5 ns | 7 ns (**1.48×**) † | 74 ns (**14.68×**) † | 106 ns (**20.96×**) † |
-| `<< 61` | 181 ns | 33 ns (0.18×) | 165 ns (0.91×) † | 235 ns (**1.30×**) † |
-| `>> 61` | 179 ns | 32 ns (0.18×) | 173 ns (0.97×) † | 228 ns (**1.28×**) † |
-| `description` | 9.39 µs | 1.46 µs (0.16×) | 1.47 µs (0.16×) | 1.99 µs (0.21×) |
-| `init(radix: 10)` | 16.54 µs | 551 ns (0.03×) | 1.14 µs (0.07×) | 6.45 µs (0.39×) |
-| `init(radix: 16)` | 15.06 µs | 361 ns (0.02×) | 457 ns (0.03×) | 1.04 µs (0.07×) |
-| `squareRoot` | 15.29 µs | — | 1.65 µs (0.11×) | 2.35 µs (0.15×) |
-| `gcd` | 28.99 µs | — | 3.76 µs (0.13×) | 44.44 µs (**1.53×**) |
-| `power(5)` | 4.57 µs | 1.78 µs (0.39×) | 11.15 µs (**2.44×**) | 9.21 µs (**2.02×**) |
-| `power(e, mod:)` | 25.15 ms | — | 16.33 ms (0.65×) | 17.78 ms (0.71×) |
+| `baseline` | 11 ns | 13 ns (**1.19×**) | 134 ns (**11.82×**) | 205 ns (**18.13×**) |
+| `+` | 96 ns | 32 ns (0.34×) | 174 ns (**1.81×**) † | 349 ns (**3.64×**) † |
+| `-` | 95 ns | 35 ns (0.36×) | 174 ns (**1.82×**) † | 348 ns (**3.66×**) † |
+| `*` | 576 ns | 219 ns (0.38×) | 2.18 µs (**3.78×**) | 1.28 µs (**2.22×**) |
+| `/` | 2.47 µs | 895 ns (0.36×) | 2.94 µs (**1.19×**) | 2.62 µs (**1.06×**) |
+| `%` | 2.53 µs | 909 ns (0.36×) | 2.93 µs (**1.16×**) | 2.49 µs (0.98×) |
+| `<` | 5 ns | 7 ns (**1.40×**) † | 74 ns (**14.35×**) † | 70 ns (**13.53×**) † |
+| `<< 61` | 168 ns | 33 ns (0.20×) | 166 ns (0.99×) † | 356 ns (**2.12×**) † |
+| `>> 61` | 158 ns | 32 ns (0.20×) | 175 ns (**1.10×**) † | 345 ns (**2.18×**) † |
+| `description` | 1.84 µs | 1.46 µs (0.79×) | 1.53 µs (0.83×) | 2.03 µs (**1.10×**) |
+| `init(radix: 10)` | 639 ns | 545 ns (0.85×) | 1.17 µs (**1.83×**) | 6.54 µs (**10.23×**) |
+| `init(radix: 16)` | 575 ns | 363 ns (0.63×) | 465 ns (0.81×) | 1.19 µs (**2.07×**) |
+| `squareRoot` | 14.90 µs | — | 1.65 µs (0.11×) | 5.01 µs (0.34×) |
+| `gcd` | 25.87 µs | — | 3.81 µs (0.15×) | 106.84 µs (**4.13×**) |
+| `power(5)` | 4.47 µs | 1.77 µs (0.40×) | 11.24 µs (**2.51×**) | 10.50 µs (**2.35×**) |
+| `power(e, mod:)` | 25.03 ms | — | 16.57 ms (0.66×) | 18.56 ms (0.74×) |
 
 ### 4096 bits
 
 | operation | swift-bignum | node | python | ruby |
 |---|---:|---:|---:|---:|
-| `baseline` | 11 ns | 14 ns (**1.20×**) | 136 ns (**11.92×**) | 249 ns (**21.76×**) |
-| `+` | 190 ns | 89 ns (0.47×) | 305 ns (**1.60×**) | 406 ns (**2.13×**) † |
-| `-` | 439 ns | 140 ns (0.32×) | 347 ns (0.79×) | 455 ns (**1.04×**) † |
-| `*` | 6.25 µs | 2.52 µs (0.40×) | 17.88 µs (**2.86×**) | 14.41 µs (**2.30×**) |
-| `/` | 16.47 µs | 8.22 µs (0.50×) | 37.71 µs (**2.29×**) | 30.10 µs (**1.83×**) |
-| `%` | 16.06 µs | 8.29 µs (0.52×) | 37.96 µs (**2.36×**) | 29.93 µs (**1.86×**) |
-| `<` | 5 ns | 10 ns (**1.92×**) † | 83 ns (**16.08×**) † | 102 ns (**19.82×**) † |
-| `<< 61` | 276 ns | 64 ns (0.23×) | 272 ns (0.98×) † | 365 ns (**1.32×**) † |
-| `>> 61` | 262 ns | 68 ns (0.26×) | 280 ns (**1.07×**) | 330 ns (**1.26×**) † |
-| `description` | 53.28 µs | 17.59 µs (0.33×) | 17.83 µs (0.33×) | 16.55 µs (0.31×) |
-| `init(radix: 10)` | 65.78 µs | 3.28 µs (0.05×) | 11.49 µs (0.17×) | 11.28 µs (0.17×) |
-| `init(radix: 16)` | 61.54 µs | 1.08 µs (0.02×) | 1.29 µs (0.02×) | 3.44 µs (0.06×) |
-| `squareRoot` | 92.03 µs | — | 12.30 µs (0.13×) | 11.67 µs (0.13×) |
-| `gcd` | 553.87 µs | — | 24.55 µs (0.04×) | 513.02 µs (0.93×) |
-| `power(5)` | 132.94 µs | 21.14 µs (0.16×) | 124.83 µs (0.94×) | 89.07 µs (0.67×) |
+| `baseline` | 11 ns | 13 ns (**1.19×**) | 135 ns (**11.82×**) | 303 ns (**26.67×**) |
+| `+` | 191 ns | 90 ns (0.47×) | 306 ns (**1.60×**) | 549 ns (**2.88×**) † |
+| `-` | 201 ns | 139 ns (0.69×) | 348 ns (**1.73×**) | 681 ns (**3.38×**) |
+| `*` | 5.98 µs | 2.51 µs (0.42×) | 17.89 µs (**2.99×**) | 14.54 µs (**2.43×**) |
+| `/` | 16.26 µs | 8.22 µs (0.51×) | 38.06 µs (**2.34×**) | 30.44 µs (**1.87×**) |
+| `%` | 16.27 µs | 8.21 µs (0.50×) | 38.00 µs (**2.34×**) | 30.35 µs (**1.87×**) |
+| `<` | 5 ns | 10 ns (**1.90×**) † | 80 ns (**16.06×**) † | 70 ns (**14.04×**) † |
+| `<< 61` | 221 ns | 63 ns (0.29×) | 268 ns (**1.21×**) † | 522 ns (**2.36×**) † |
+| `>> 61` | 176 ns | 67 ns (0.38×) | 281 ns (**1.60×**) | 505 ns (**2.87×**) † |
+| `description` | 25.28 µs | 17.51 µs (0.69×) | 18.05 µs (0.71×) | 16.86 µs (0.67×) |
+| `init(radix: 10)` | 3.20 µs | 3.30 µs (**1.03×**) | 11.68 µs (**3.64×**) | 12.25 µs (**3.82×**) |
+| `init(radix: 16)` | 1.86 µs | 1.07 µs (0.58×) | 1.32 µs (0.71×) | 3.88 µs (**2.08×**) |
+| `squareRoot` | 93.83 µs | — | 12.22 µs (0.13×) | 78.60 µs (0.84×) |
+| `gcd` | 568.15 µs | — | 24.42 µs (0.04×) | 784.00 µs (**1.38×**) |
+| `power(5)` | 128.12 µs | 21.02 µs (0.16×) | 125.28 µs (0.98×) | 93.99 µs (0.73×) |
 
 ### Summary
 
@@ -151,134 +199,86 @@ Greater than 1 means swift-bignum was faster.
 
 | | 64 bits | 256 bits | 1024 bits | 4096 bits |
 |---|---:|---:|---:|---:|
-| node | 0.11× | 0.13× | 0.18× | 0.32× |
-| python | 0.28× | 0.49× | **1.17×** | **1.07×** |
-| ruby | 0.21× | 0.39× | 0.94× | 0.67× |
+| node | 0.15× | 0.39× | 0.36× | 0.50× |
+| python | 0.35× | 0.90× | **1.19×** | **1.73×** |
+| ruby | 0.43× | **1.29×** | **2.07×** | **2.08×** |
 
 Operations counted: those that clear 2× their own harness's `baseline` on both sides, out of `+`, `-`, `*`, `/`, `%`, `<`, `<< 61`, `>> 61`, `description`, `init(radix: 10)`, `init(radix: 16)`, `power(5)`. A † in the tables above marks a cell that does not, and is therefore mostly measuring the loop rather than the arithmetic.
 
-### What this says
+### Is it faster than the dynamically-typed languages?
 
-* **V8 wins nearly everything.** Node is 0.11×–0.52× at every size and every
-  operation except `<` and the `baseline` row itself. Its BigInt is a tuned C++
-  implementation with a fast path for small values, and the gap narrows as
-  operands grow — 0.11× median at 64 bits to 0.32× at 4096 — which is the same
-  asymptotic story as the attaswift comparison, told from further behind.
-* **Python and Ruby lose small, and win where the operands are large.** Both sit
-  at 0.2–0.5× below 1024 bits, where their interpreter loop dominates. Above that
-  the picture splits: Python's median crosses 1 (1.17× at 1024, 1.07× at 4096),
-  while Ruby's peaks at 0.94× and falls back to 0.67× — but both beat us
-  decisively on the two operations that dominate real bignum work. At 4096 bits
-  CPython is 2.86× our `*` and 2.29× our `/`; Ruby is 2.30× and 1.83×.
-* **Two gaps widen as the operands grow**, which is the signature of a
-  different algorithm rather than a slower constant. See below.
+Above 256 bits, yes; below it, no.
 
-### Where the gap widens with size, and where it is just a constant
+* **Python**: behind at 64 bits (0.35×), level at 256 (0.90×), ahead at 1024 and
+  4096 (1.19×, 1.73×).
+* **Ruby 2.6**: behind at 64 bits (0.43×), ahead from 256 bits up (1.29×, 2.07×,
+  2.08×).
+* **Node**: behind everywhere, 0.15× to 0.50×, though the gap halves as operands
+  grow.
 
-Whether a gap grows as the operands grow is the interesting question: a widening
-gap means a different algorithm, a flat one means a slower version of the same
-idea. Ratios of CPython's time to ours, below 1 meaning CPython is faster:
+At 64 bits the operations still lost to CPython are `/`, `%`, `<<`, `>>`,
+`description`, `power(5)` and `power(e, mod:)`. The first four have the same
+cause, and it is not the arithmetic: **every operation that returns a new value
+allocates an array for it**, which is 40–60 ns before any work happens, and our
+`baseline` of 11 ns is what one closure call and one fold cost with no allocation
+at all. CPython and Ruby pay ~130 ns of interpreter loop per iteration but hand
+out small integers from a free list, so on a 64-bit operand they are comparing
+their allocator against ours and winning. Closing that means storing small values
+inline instead of in a heap array — a change to the storage type itself, not to
+any algorithm, and much larger than anything above.
 
-| operation | 64 bits | 256 bits | 1024 bits | 4096 bits | |
-|---|---:|---:|---:|---:|---|
-| `init(radix: 16)` | 0.118 | 0.059 | 0.030 | 0.021 | widens |
-| `gcd` | 0.367 | 0.317 | 0.130 | 0.044 | widens |
-| `squareRoot` | 1.345 | 0.079 | 0.108 | 0.134 | flat |
-| `description` | 0.200 | 0.105 | 0.157 | 0.335 | flat |
+`power(5)` and `power(e, mod:)` are different: both are dominated by mid-size
+multiplication and by division, and modular exponentiation additionally reduces
+in full at every exponent bit where windowing and Montgomery multiplication are
+the standard answers. Neither is implemented.
 
-**Two of these are ours to fix, and the evidence is internal rather than
-comparative:**
+### `>> 1` on negative values, across five implementations
 
-* **`init(radix: 16)` does work it does not need to.** At 4096 bits it costs
-  61.5 µs against 1.08 µs in Node and 1.29 µs in Python, and the gap widens by
-  nearly 6× from 64 bits to 4096 — the signature of quadratic against linear. The
-  telling comparison is with our own decimal parser: hex costs 61.5 µs and
-  decimal 65.8 µs, essentially the same. Decimal *has* to multiply. Hex does not,
-  since 16 is a power of two and its digits can be packed straight into limbs. We
-  run the same chunked multiply-and-add for both.
-* **`gcd` stops scaling.** 553.9 µs at 4096 bits against CPython's 24.6 µs, the
-  ratio falling from 0.37 to 0.04 as operands grow. Stein's binary GCD is a good
-  choice when small — it beats attaswift by 1.6–2.9× at every size — but each step
-  removes about one bit while touching every limb, so it is quadratic in the limb
-  count. The subquadratic methods work on the leading words and apply the result
-  to the whole number; a gap that widens like this is what points to one. Ruby, at
-  513 µs, sits beside us rather than beside CPython.
+| value | swift-bignum | node | python | ruby | attaswift |
+|---:|---:|---:|---:|---:|---:|
+| -1 | -1 | -1 | -1 | -1 | -1 |
+| -2 | -1 | -1 | -1 | -1 | -1 |
+| -3 | -2 | -2 | -2 | -2 | **-1** |
+| -5 | -3 | -3 | -3 | -3 | **-2** |
+| -7 | -4 | -4 | -4 | -4 | **-3** |
+| -8 | -4 | -4 | -4 | -4 | -4 |
+| -1025 | -513 | -513 | -513 | -513 | **-512** |
 
-**`squareRoot` and `description` are flat**, which makes them constant factors
-rather than wrong algorithms — roughly 8–12× on the square root above 256 bits and
-3–10× on decimal output, steady across sizes. Worth less than the two above.
-
-`power(e, mod:)` is the near miss: 25.2 ms against Python's 16.3 ms at 1024 bits,
-so 0.65×. Ours is square-and-multiply with a full reduction per exponent bit,
-which is the naive schedule; windowed exponentiation and Montgomery
-multiplication are the standard improvements, and neither is implemented here.
-
-None of this is addressed in this change. Measuring is one job; fixing is another,
-with its own tests.
+Agreeing: swift-bignum, node, python, ruby. Differing: attaswift.
 
 ## Against attaswift/BigInt
 
-### Where each one wins
-
 Ratios are attaswift's time over ours, so **greater than 1 means swift-bignum is
-faster**. Anything within about 1.15× is noise (run-to-run variation on the same
-machine was under 5%).
+faster**. Anything within about 1.15× is noise.
 
 | operation | 64 bits | 256 bits | 1024 bits | 4096 bits |
 |---|---:|---:|---:|---:|
-| `+` | **1.48×** | **2.15×** | **2.27×** | **1.98×** |
-| `-` | 0.56× | 0.63× | 0.70× | 0.85× |
-| `*` | 0.48× | 1.09× | **2.74×** | **4.01×** |
-| `* (negative)` | 0.49× | 1.10× | **2.54×** | **3.87×** |
-| `/` | 0.47× | 0.77× | **1.42×** | **3.07×** |
-| `%` | 0.56× | 0.67× | **1.35×** | **3.04×** |
-| `<` | **1.20×** | **1.20×** | **1.20×** | **1.20×** |
-| `<< 61` | 0.60× | **1.36×** | **3.23×** | **5.38×** |
-| `>> 61` | 0.60× | 1.04× | **1.22×** | **1.37×** |
-| `>> 61 (negative)` | n/c | n/c | n/c | n/c |
-| `& (negative)` | **1.70×** | **1.84×** | **2.05×** | **1.93×** |
-| `~ (negative)` | **1.31×** | **1.32×** | **1.18×** | 0.93× |
-| `description` | 0.48× | 0.45× | 0.59× | 0.97× |
-| `init(radix: 10)` | 0.50× | 0.63× | 0.70× | 0.76× |
-| `init(radix: 16)` | 0.44× | 0.59× | 0.62× | 0.58× |
-| `squareRoot` | **6.67×** | 0.71× | 0.96× | **1.74×** |
-| `gcd` | **1.60×** | **2.38×** | **2.85×** | **1.59×** |
-| `power(5)` | 0.44× | **2.11×** | **9.06×** | **5.11×** |
-| `power(e, mod:)` | 0.42× | 0.93× | **1.33×** | — |
+| `baseline` | **2.45×** | **2.45×** | **2.46×** | **2.53×** |
+| `+` | **1.47×** | **2.22×** | **2.27×** | **1.97×** |
+| `-` | **1.37×** | **1.50×** | **1.68×** | **1.89×** |
+| `*` | **2.04×** | **1.09×** | **2.76×** | **4.42×** |
+| `* (negative)` | **2.02×** | **1.10×** | **2.57×** | **4.22×** |
+| `/` | 0.47× | 0.77× | **1.48×** | **3.04×** |
+| `%` | 0.56× | 0.66× | **1.38×** | **3.02×** |
+| `<` | **1.13×** | **1.18×** | **1.13×** | **1.19×** |
+| `<< 61` | 0.63× | **1.37×** | **3.47×** | **6.61×** |
+| `>> 61` | 0.62× | **1.07×** | **1.38×** | **2.03×** |
+| `>> 61 (negative)` | not comparable | not comparable | not comparable | not comparable |
+| `& (negative)` | **1.69×** | **1.84×** | **2.05×** | **1.91×** |
+| `~ (negative)` | **1.33×** | **1.33×** | **1.23×** | 0.94× |
+| `description` | **1.14×** | **2.47×** | **3.04×** | **2.03×** |
+| `init(radix: 10)` | **5.73×** | **12.51×** | **17.30×** | **15.39×** |
+| `init(radix: 16)` | **4.21×** | **9.61×** | **15.85×** | **19.55×** |
+| `squareRoot` | **6.67×** | 0.73× | 0.96× | **1.77×** |
+| `gcd` | **10.41×** | **2.36×** | **2.59×** | **1.55×** |
+| `power(5)` | 0.54× | **2.16×** | **9.57×** | **5.38×** |
+| `power(e, mod:)` | 0.42× | 0.93× | **1.40×** | — |
 
-The pattern is asymptotic against constant. **swift-bignum wins as operands grow
-and loses at one or two limbs**, and the crossover is visible in `*` (0.48× at 64
-bits, 4.01× at 4096) and in `/` and `%`. Karatsuba above 40 limbs is part of it;
-the rest is that attaswift's per-call overhead is lower and ours does not shrink
-with the operand. `<< 61` costs us 166 ns on one limb and 275 ns on 64 of them —
-a 64× larger input for 1.7× the time — which is a fixed cost per call, not work.
-
-Three groups stand out:
-
-* **Two's complement pays where it should.** `+`, `&` and `~` on negative values
-  read straight off the storage, with no sign to case-analyse: 1.5–2.3× on `+`
-  and 1.7–2.1× on `&` at every size. That was the reason for the representation
-  and it shows up as expected.
-* **`power` and `gcd` are the largest wins.** `power(5)` is 9× at 1024 bits, and
-  Stein's binary gcd on the limbs is 1.6–2.9× throughout.
-* **String conversion is the standing loss.** Both parsers are 0.44–0.76× at
-  every size, and `description` is 0.45–0.59× until it reaches parity at 4096
-  bits. Chunking by the largest power of the radix that fits a limb was supposed
-  to settle this and evidently does not; attaswift is simply better at it.
-
-### Two things this measured that look fixable
-
-Neither is a design consequence, so they are worth recording as leads rather than
-as facts about two's complement:
-
-* **`-` is `lhs + (-rhs)`.** That is two passes over the limbs and two
-  allocations where one of each would do, and it shows: our `-` costs 2.3–2.5×
-  our `+` at every size, while attaswift's `-` is never slower than its `+`. It
-  is the only arithmetic operation we lose at *every* size — and we win `+`
-  everywhere by 1.5–2.3×, so the subtraction is leaving that on the table.
-* **Small operands carry a constant we do not need.** Most of the 64-bit losses
-  are in the 100–170 ns range against attaswift's ~100 ns, on work that is a
-  handful of instructions. Allocation per result is the obvious suspect.
+`+`, `-`, `*`, `&`, `~`, both parsers, `squareRoot` and `gcd` now win at every
+size, and `description` has gone from 0.45–0.59× to roughly parity. What remains
+against us is `/` and `%` below 1024 bits, the shifts, and the two exponentiation
+rows — the same allocation floor described above, since attaswift's per-call
+overhead is lower than ours and does not shrink with the operand.
 
 ## Method
 
@@ -299,108 +299,126 @@ as facts about two's complement:
   1.4× difference rather than the ~10× that hoisting would show, so V8 is doing
   the work.
 * Each harness measures its own `baseline` — the loop and the result-folding with
-  no arithmetic — and it is reported as a row rather than subtracted, because the
-  fold is not the same cost for every operation and a subtracted number would
-  imply a precision that is not there.
+  no arithmetic — reported as a row rather than subtracted, because the fold is
+  not the same cost for every operation and a subtracted number would imply a
+  precision that is not there.
 * A debug build reports the absence of the optimizer rather than the algorithms,
   so the Swift harness says so loudly if it is built without `-c release`.
 
 Two things the numbers cannot tell you. The interpreted harnesses pay for their
 own loop on every iteration and the compiled one does not, so any row within a
-small multiple of its `baseline` is not a measurement of arithmetic. And Node,
-CPython and Ruby have no equivalent of the others' *language* overhead — a
-tight Swift loop over `BigInt` is not what code in those languages looks like, so
-these ratios are about the bignum implementations, not about the languages.
+small multiple of its `baseline` is not a measurement of arithmetic. And a tight
+Swift loop over `BigInt` is not what code in those languages looks like, so these
+ratios are about the bignum implementations, not about the languages.
 
 Measured on an Apple M1 (8 cores), macOS 26.6.1, Swift 6.3.3, against
 attaswift/BigInt **5.7.0**, node **v24.18.0** (V8 13.6), CPython **3.9.6**, and
-Ruby **4.0.6** built `--without-gmp` — which matters, since a GMP-backed Ruby
-would be a different measurement entirely at the large sizes.
-`Package.resolved` is not checked in, so a later run may pick up a newer
-attaswift 5.x; `swift package resolve && cat Package.resolved` in `Benchmarks/`
-says which version you actually got.
+ruby 2.6.10 (/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby, GMP possible). `Package.resolved` is not checked in, so a later
+run may pick up a newer attaswift 5.x; `swift package resolve && cat
+Package.resolved` in `Benchmarks/` says which version you actually got.
 
 ## Appendix: absolute times against attaswift
 
 | operation | bits | swift-bignum | attaswift | ratio |
-| `+` | 64 | 75 ns | 111 ns | **1.48×** |
-| `-` | 64 | 189 ns | 105 ns | 0.56× |
-| `*` | 64 | 223 ns | 108 ns | 0.49× |
-| `* (negative)` | 64 | 220 ns | 108 ns | 0.49× |
-| `/` | 64 | 272 ns | 128 ns | 0.47× |
-| `%` | 64 | 272 ns | 153 ns | 0.56× |
-| `<` | 64 | 5 ns | 6 ns | **1.12×** |
-| `<< 61` | 64 | 166 ns | 99 ns | 0.60× |
-| `>> 61` | 64 | 165 ns | 99 ns | 0.60× |
-| `>> 61 (negative)` | 64 | 166 ns | 99 ns | not comparable |
-| `& (negative)` | 64 | 73 ns | 124 ns | **1.70×** |
-| `~ (negative)` | 64 | 72 ns | 94 ns | **1.31×** |
-| `description` | 64 | 892 ns | 424 ns | 0.48× |
-| `init(radix: 10)` | 64 | 1.95 µs | 969 ns | 0.50× |
-| `init(radix: 16)` | 64 | 1.72 µs | 762 ns | 0.44× |
-| `squareRoot` | 64 | 137 ns | 914 ns | **6.65×** |
-| `gcd` | 64 | 783 ns | 1.25 µs | **1.60×** |
-| `power(5)` | 64 | 1.59 µs | 692 ns | 0.44× |
-| `power(e, mod:)` | 64 | 99.91 µs | 41.58 µs | 0.42× |
-| `+` | 256 | 79 ns | 170 ns | **2.16×** |
-| `-` | 256 | 195 ns | 122 ns | 0.63× |
-| `*` | 256 | 303 ns | 331 ns | **1.09×** |
-| `* (negative)` | 256 | 302 ns | 331 ns | **1.09×** |
-| `/` | 256 | 906 ns | 694 ns | 0.77× |
-| `%` | 256 | 905 ns | 610 ns | 0.67× |
-| `<` | 256 | 5 ns | 6 ns | **1.19×** |
-| `<< 61` | 256 | 169 ns | 229 ns | **1.35×** |
-| `>> 61` | 256 | 168 ns | 175 ns | **1.04×** |
-| `>> 61 (negative)` | 256 | 168 ns | 175 ns | not comparable |
-| `& (negative)` | 256 | 73 ns | 134 ns | **1.84×** |
-| `~ (negative)` | 256 | 71 ns | 94 ns | **1.32×** |
-| `description` | 256 | 2.60 µs | 1.18 µs | 0.46× |
-| `init(radix: 10)` | 256 | 4.76 µs | 3.02 µs | 0.63× |
-| `init(radix: 16)` | 256 | 4.20 µs | 2.49 µs | 0.59× |
-| `squareRoot` | 256 | 6.05 µs | 4.28 µs | 0.71× |
-| `gcd` | 256 | 3.09 µs | 7.35 µs | **2.38×** |
-| `power(5)` | 256 | 1.61 µs | 3.40 µs | **2.12×** |
-| `power(e, mod:)` | 256 | 933.72 µs | 868.71 µs | 0.93× |
-| `+` | 1024 | 95 ns | 216 ns | **2.27×** |
-| `-` | 1024 | 232 ns | 163 ns | 0.70× |
-| `*` | 1024 | 583 ns | 1.60 µs | **2.74×** |
-| `* (negative)` | 1024 | 630 ns | 1.60 µs | **2.54×** |
-| `/` | 1024 | 2.50 µs | 3.55 µs | **1.42×** |
-| `%` | 1024 | 2.52 µs | 3.41 µs | **1.36×** |
-| `<` | 1024 | 5 ns | 6 ns | **1.12×** |
-| `<< 61` | 1024 | 183 ns | 591 ns | **3.22×** |
-| `>> 61` | 1024 | 181 ns | 221 ns | **1.23×** |
-| `>> 61 (negative)` | 1024 | 182 ns | 221 ns | not comparable |
-| `& (negative)` | 1024 | 85 ns | 174 ns | **2.06×** |
-| `~ (negative)` | 1024 | 78 ns | 92 ns | **1.18×** |
-| `description` | 1024 | 9.41 µs | 5.56 µs | 0.59× |
-| `init(radix: 10)` | 1024 | 16.09 µs | 11.25 µs | 0.70× |
-| `init(radix: 16)` | 1024 | 15.02 µs | 9.30 µs | 0.62× |
-| `squareRoot` | 1024 | 15.12 µs | 14.46 µs | 0.96× |
-| `gcd` | 1024 | 23.72 µs | 67.59 µs | **2.85×** |
-| `power(5)` | 1024 | 4.61 µs | 41.76 µs | **9.07×** |
-| `power(e, mod:)` | 1024 | 25.63 ms | 34.21 ms | **1.33×** |
-| `+` | 4096 | 190 ns | 377 ns | **1.99×** |
-| `-` | 4096 | 437 ns | 371 ns | 0.85× |
-| `*` | 4096 | 6.17 µs | 24.76 µs | **4.02×** |
-| `* (negative)` | 4096 | 6.38 µs | 24.70 µs | **3.87×** |
-| `/` | 4096 | 16.06 µs | 49.27 µs | **3.07×** |
-| `%` | 4096 | 15.96 µs | 48.53 µs | **3.04×** |
+|---|---:|---:|---:|---:|
+| `baseline` | 64 | 11 ns | 28 ns | **2.45×** |
+| `+` | 64 | 75 ns | 111 ns | **1.47×** |
+| `-` | 64 | 78 ns | 107 ns | **1.37×** |
+| `*` | 64 | 54 ns | 110 ns | **2.04×** |
+| `* (negative)` | 64 | 54 ns | 109 ns | **2.02×** |
+| `/` | 64 | 275 ns | 128 ns | 0.47× |
+| `%` | 64 | 274 ns | 154 ns | 0.56× |
+| `<` | 64 | 5 ns | 6 ns | **1.13×** |
+| `<< 61` | 64 | 161 ns | 101 ns | 0.63× |
+| `>> 61` | 64 | 160 ns | 99 ns | 0.62× |
+| `>> 61 (negative)` | 64 | 161 ns | 99 ns | not comparable |
+| `& (negative)` | 64 | 74 ns | 125 ns | **1.69×** |
+| `~ (negative)` | 64 | 72 ns | 96 ns | **1.33×** |
+| `description` | 64 | 375 ns | 430 ns | **1.14×** |
+| `init(radix: 10)` | 64 | 168 ns | 962 ns | **5.73×** |
+| `init(radix: 16)` | 64 | 181 ns | 761 ns | **4.21×** |
+| `squareRoot` | 64 | 139 ns | 928 ns | **6.67×** |
+| `gcd` | 64 | 121 ns | 1.26 µs | **10.41×** |
+| `power(5)` | 64 | 1.29 µs | 697 ns | 0.54× |
+| `power(e, mod:)` | 64 | 99.42 µs | 41.72 µs | 0.42× |
+| `baseline` | 256 | 11 ns | 28 ns | **2.45×** |
+| `+` | 256 | 79 ns | 175 ns | **2.22×** |
+| `-` | 256 | 82 ns | 123 ns | **1.50×** |
+| `*` | 256 | 304 ns | 331 ns | **1.09×** |
+| `* (negative)` | 256 | 300 ns | 330 ns | **1.10×** |
+| `/` | 256 | 911 ns | 705 ns | 0.77× |
+| `%` | 256 | 933 ns | 615 ns | 0.66× |
+| `<` | 256 | 5 ns | 6 ns | **1.18×** |
+| `<< 61` | 256 | 166 ns | 227 ns | **1.37×** |
+| `>> 61` | 256 | 162 ns | 174 ns | **1.07×** |
+| `>> 61 (negative)` | 256 | 160 ns | 175 ns | not comparable |
+| `& (negative)` | 256 | 72 ns | 133 ns | **1.84×** |
+| `~ (negative)` | 256 | 71 ns | 94 ns | **1.33×** |
+| `description` | 256 | 482 ns | 1.19 µs | **2.47×** |
+| `init(radix: 10)` | 256 | 247 ns | 3.09 µs | **12.51×** |
+| `init(radix: 16)` | 256 | 257 ns | 2.47 µs | **9.61×** |
+| `squareRoot` | 256 | 6.04 µs | 4.41 µs | 0.73× |
+| `gcd` | 256 | 3.17 µs | 7.47 µs | **2.36×** |
+| `power(5)` | 256 | 1.56 µs | 3.39 µs | **2.16×** |
+| `power(e, mod:)` | 256 | 917.91 µs | 858.20 µs | 0.93× |
+| `baseline` | 1024 | 11 ns | 28 ns | **2.46×** |
+| `+` | 1024 | 96 ns | 217 ns | **2.27×** |
+| `-` | 1024 | 95 ns | 160 ns | **1.68×** |
+| `*` | 1024 | 576 ns | 1.59 µs | **2.76×** |
+| `* (negative)` | 1024 | 605 ns | 1.55 µs | **2.57×** |
+| `/` | 1024 | 2.47 µs | 3.65 µs | **1.48×** |
+| `%` | 1024 | 2.53 µs | 3.49 µs | **1.38×** |
+| `<` | 1024 | 5 ns | 6 ns | **1.13×** |
+| `<< 61` | 1024 | 168 ns | 584 ns | **3.47×** |
+| `>> 61` | 1024 | 158 ns | 218 ns | **1.38×** |
+| `>> 61 (negative)` | 1024 | 159 ns | 220 ns | not comparable |
+| `& (negative)` | 1024 | 85 ns | 173 ns | **2.05×** |
+| `~ (negative)` | 1024 | 76 ns | 93 ns | **1.23×** |
+| `description` | 1024 | 1.84 µs | 5.60 µs | **3.04×** |
+| `init(radix: 10)` | 1024 | 639 ns | 11.06 µs | **17.30×** |
+| `init(radix: 16)` | 1024 | 575 ns | 9.11 µs | **15.85×** |
+| `squareRoot` | 1024 | 14.90 µs | 14.28 µs | 0.96× |
+| `gcd` | 1024 | 25.87 µs | 66.96 µs | **2.59×** |
+| `power(5)` | 1024 | 4.47 µs | 42.78 µs | **9.57×** |
+| `power(e, mod:)` | 1024 | 25.03 ms | 35.07 ms | **1.40×** |
+| `baseline` | 4096 | 11 ns | 29 ns | **2.53×** |
+| `+` | 4096 | 191 ns | 376 ns | **1.97×** |
+| `-` | 4096 | 201 ns | 381 ns | **1.89×** |
+| `*` | 4096 | 5.98 µs | 26.42 µs | **4.42×** |
+| `* (negative)` | 4096 | 6.17 µs | 26.04 µs | **4.22×** |
+| `/` | 4096 | 16.26 µs | 49.42 µs | **3.04×** |
+| `%` | 4096 | 16.27 µs | 49.18 µs | **3.02×** |
 | `<` | 4096 | 5 ns | 6 ns | **1.19×** |
-| `<< 61` | 4096 | 275 ns | 1.48 µs | **5.37×** |
-| `>> 61` | 4096 | 264 ns | 362 ns | **1.37×** |
-| `>> 61 (negative)` | 4096 | 264 ns | 363 ns | not comparable |
-| `& (negative)` | 4096 | 189 ns | 365 ns | **1.93×** |
-| `~ (negative)` | 4096 | 108 ns | 100 ns | 0.93× |
-| `description` | 4096 | 52.84 µs | 51.46 µs | 0.97× |
-| `init(radix: 10)` | 4096 | 65.92 µs | 50.06 µs | 0.76× |
-| `init(radix: 16)` | 4096 | 61.88 µs | 36.13 µs | 0.58× |
-| `squareRoot` | 4096 | 93.00 µs | 161.84 µs | **1.74×** |
-| `gcd` | 4096 | 551.89 µs | 876.29 µs | **1.59×** |
-| `power(5)` | 4096 | 134.93 µs | 689.73 µs | **5.11×** |
+| `<< 61` | 4096 | 221 ns | 1.46 µs | **6.61×** |
+| `>> 61` | 4096 | 176 ns | 357 ns | **2.03×** |
+| `>> 61 (negative)` | 4096 | 181 ns | 372 ns | not comparable |
+| `& (negative)` | 4096 | 191 ns | 364 ns | **1.91×** |
+| `~ (negative)` | 4096 | 108 ns | 102 ns | 0.94× |
+| `description` | 4096 | 25.28 µs | 51.42 µs | **2.03×** |
+| `init(radix: 10)` | 4096 | 3.20 µs | 49.32 µs | **15.39×** |
+| `init(radix: 16)` | 4096 | 1.86 µs | 36.36 µs | **19.55×** |
+| `squareRoot` | 4096 | 93.83 µs | 165.87 µs | **1.77×** |
+| `gcd` | 4096 | 568.15 µs | 880.69 µs | **1.55×** |
+| `power(5)` | 4096 | 128.12 µs | 688.73 µs | **5.38×** |
 
-Ours and theirs are `BigInt` in both cases: signed, arbitrary precision. Both
-libraries are being asked for the same answers, and — apart from the one row
-above — both give them.
+79 cases, 75 in agreement.
+
+Disagreed, so no ratio is reported for them: `>> 61 (negative)`.
+
+`>> 1` against `Int`, which defines the contract:
+
+| value | `Int` | swift-bignum | attaswift |
+|---:|---:|---:|---:|
+| -1 | -1 | -1 | -1 |
+| -2 | -1 | -1 | -1 |
+| -3 | -2 | -2 | -1 **differs** |
+| -5 | -3 | -3 | -2 **differs** |
+| -7 | -4 | -4 | -3 **differs** |
+| -8 | -4 | -4 | -4 |
+| -1025 | -513 | -513 | -512 **differs** |
+
+swift-bignum matches `Int` in 7 of 7 cases; attaswift in 3.
+
+Cores: 8. Checksum: 10200016186030546150.
 
 [attaswift/BigInt]: https://github.com/attaswift/BigInt

--- a/Benchmarks/cross/bench.rb
+++ b/Benchmarks/cross/bench.rb
@@ -92,5 +92,10 @@ semantics = [-1, -2, -3, -5, -7, -8, -1025].map { |v| [v, v >> 1] }
 write(out_dir, 'results-ruby.tsv', %w[op bits ns], results)
 write(out_dir, 'values-ruby.tsv', %w[op bits value], values)
 write(out_dir, 'semantics-ruby.tsv', %w[value shifted], semantics)
-gmp = RbConfig::CONFIG['configure_args'].to_s.include?('without-gmp') ? 'no GMP' : 'GMP possible'
-$stderr.puts "\nruby #{RUBY_VERSION} (#{gmp}). Checksum: #{$checksum}"
+args = RbConfig::CONFIG['configure_args'].to_s
+gmp = if args.include?('without-gmp') then 'built without GMP'
+      elsif args.include?('with-gmp') then 'built with GMP'
+      else 'GMP not mentioned either way in configure_args'
+      end
+File.write("#{out_dir}/version-ruby.txt", "ruby #{RUBY_VERSION} (#{RbConfig.ruby}, #{gmp})\n")
+$stderr.puts "\nruby #{RUBY_VERSION} at #{RbConfig.ruby} (#{gmp}). Checksum: #{$checksum}"

--- a/Benchmarks/cross/run.sh
+++ b/Benchmarks/cross/run.sh
@@ -19,8 +19,14 @@ set -e
 cd "$(dirname "$0")/.."
 mkdir -p .out
 
+# macOS ships /usr/bin/ruby, and a Mac with Homebrew or MacPorts on PATH has a
+# much newer one that measures very differently.  Default to the system copy and
+# say which was used; override with RUBY=/path/to/ruby.
+RUBY="${RUBY:-/usr/bin/ruby}"
+command -v "$RUBY" > /dev/null 2>&1 || RUBY=ruby
+
 missing=""
-for tool in node python3 ruby; do
+for tool in node python3 "$RUBY"; do
     command -v "$tool" > /dev/null 2>&1 || missing="$missing $tool"
 done
 if [ -n "$missing" ]; then
@@ -35,8 +41,8 @@ echo "=== node" >&2
 node    cross/bench.js .out/inputs.tsv .out
 echo "=== python" >&2
 python3 cross/bench.py .out/inputs.tsv .out
-echo "=== ruby" >&2
-ruby    cross/bench.rb .out/inputs.tsv .out
+echo "=== ruby ($RUBY, $("$RUBY" -e 'print RUBY_VERSION'))" >&2
+"$RUBY" cross/bench.rb .out/inputs.tsv .out
 
 echo "=== merging" >&2
 python3 cross/merge.py .out

--- a/README.md
+++ b/README.md
@@ -218,11 +218,15 @@ cd Benchmarks && swift run -c release      # against attaswift
 cd Benchmarks && sh cross/run.sh           # and against node, python, ruby
 ```
 
-Briefly: faster than attaswift as operands grow and slower at one or two limbs;
-comfortably behind V8's `BigInt` everywhere; ahead of CPython and Ruby below 1024
-bits and behind them on multiplication and division above it. Five
-implementations were asked to right-shift a negative number and attaswift is the
-only one that answers differently.
+Briefly: ahead of attaswift on most operations at every size; ahead of CPython
+above 256 bits and of macOS's Ruby from 256 bits up; behind V8's `BigInt` everywhere,
+and behind all three on 64-bit operands, where one heap allocation per result is
+the floor. Five implementations were asked to right-shift a negative number and
+attaswift is the only one that answers differently.
+
+The first run of that benchmark is also why radix conversion is 9–33× faster than
+it was, `-` 2.4×, and small `*` and `gcd` 4–7× — [Benchmark.md](Benchmark.md#what-benchmarking-changed)
+records what it found and what each fix bought.
 
 That is a separate package on purpose. A benchmark target in this manifest would
 pull attaswift back in as a dependency of the root, and `swift build` would stop

--- a/Sources/BigNum/BigInt.swift
+++ b/Sources/BigNum/BigInt.swift
@@ -90,6 +90,26 @@ extension BigInt {
     @inline(__always) internal func limb(_ i: Int) -> UInt {
         return i < limbs.count ? limbs[i] : signExtension
     }
+    /// The magnitude in one limb, when it fits -- without building an array.
+    ///
+    /// Limb *count* is the wrong question: a positive value with its top bit set
+    /// carries a clear sign limb above it, so 2^63 is two limbs wide while its
+    /// magnitude is one. Every value an `Int` can hold lands here.
+    @inline(__always) internal var singleLimbMagnitude: UInt? {
+        switch limbs.count {
+        case 0:
+            return 0
+        case 1:
+            return isNegative ? 0 &- limbs[0] : limbs[0]
+        case 2:
+            // With sign extension, [lo, 0] is +lo and [lo, ~0] is lo - 2^64.
+            if limbs[1] == 0 { return limbs[0] }
+            if limbs[1] == UInt.max && limbs[0] != 0 { return 0 &- limbs[0] }
+            return nil
+        default:
+            return nil
+        }
+    }
     /// The stored limbs re-read as an unsigned magnitude.
     @usableFromInline internal var magnitudeLimbs: [UInt] {
         return isNegative ? _normalized(_negate(limbs)) : _normalized(limbs)
@@ -219,8 +239,23 @@ extension BigInt {
     public static prefix func + (x: BigInt) -> BigInt {
         return x
     }
+    /// `lhs + ~rhs + 1`, which is what two's complement subtraction *is* -- one
+    /// pass and one allocation.  Written as `lhs + (-rhs)` it was three of each,
+    /// and cost 2.3-2.5x our own `+` at every operand size while attaswift's `-`
+    /// was never slower than its `+`.
     public static func - (lhs: BigInt, rhs: BigInt) -> BigInt {
-        return lhs + (-rhs)
+        let n = Swift.max(lhs.limbs.count, rhs.limbs.count) + 1
+        var r = [UInt]()
+        r.reserveCapacity(n)
+        var carry = true                    // the +1
+        for i in 0 ..< n {
+            var (s, o1) = lhs.limb(i).addingReportingOverflow(~rhs.limb(i))
+            var o2 = false
+            if carry { (s, o2) = s.addingReportingOverflow(1) }
+            r.append(s)
+            carry = o1 || o2
+        }
+        return BigInt(limbs: r)
     }
     public mutating func negate() {
         self = -self
@@ -236,6 +271,16 @@ extension BigInt {
 
 extension BigInt {
     public static func * (lhs: BigInt, rhs: BigInt) -> BigInt {
+        // One limb each is the common case, and the general path spends four
+        // allocations on it: two magnitudes, the product, and the signed result.
+        // `multipliedFullWidth` needs none of them.  A one-limb value has
+        // magnitude at most 2^63, so both magnitudes fit a `UInt`.
+        if let x = lhs.singleLimbMagnitude, let y = rhs.singleLimbMagnitude {
+            if x == 0 || y == 0 { return BigInt() }
+            let (high, low) = x.multipliedFullWidth(by: y)
+            return BigInt(magnitude: high == 0 ? [low] : [low, high],
+                          negative: lhs.isNegative != rhs.isNegative)
+        }
         return BigInt(magnitude: _multiply(lhs.magnitudeLimbs, rhs.magnitudeLimbs),
                       negative: lhs.isNegative != rhs.isNegative)
     }
@@ -266,6 +311,13 @@ extension BigInt {
     /// every `BigRat` operation goes through, so the two intermediate `BigUInt`s
     /// the obvious spelling would build are worth skipping.
     public func greatestCommonDivisor(with other: BigInt) -> BigInt {
+        // Two magnitudes in one limb each -- every `Int`-sized pair -- run in
+        // registers, with one allocation for the answer and none for the working
+        // values.
+        if let x = self.singleLimbMagnitude, let y = other.singleLimbMagnitude {
+            let g = _gcdLimb(x, y)
+            return g == 0 ? BigInt() : BigInt(magnitude: [g], negative: false)
+        }
         return BigInt(magnitude: _gcd(self.magnitudeLimbs, other.magnitudeLimbs),
                       negative: false)
     }

--- a/Sources/BigNum/BigUInt.swift
+++ b/Sources/BigNum/BigUInt.swift
@@ -135,6 +135,39 @@ internal func _multiply(_ a: [UInt], byLimb k: UInt) -> [UInt] {
     return r
 }
 
+/// `a = a * k + addend`, in place.  One pass and at most one append, where
+/// `_multiply(_:byLimb:)` followed by `_add` would allocate twice -- which is the
+/// difference between one allocation and two per digit chunk when parsing.
+internal func _multiplyInPlace(_ a: inout [UInt], byLimb k: UInt, adding addend: UInt) {
+    if k == 0 {
+        a.removeAll(keepingCapacity: true)
+        if addend != 0 { a.append(addend) }
+        return
+    }
+    var carry = addend
+    for i in 0 ..< a.count {
+        let (high, low) = k.multipliedFullWidth(by: a[i])
+        let (s, o) = low.addingReportingOverflow(carry)
+        a[i] = s
+        carry = high &+ (o ? 1 : 0)
+    }
+    if carry != 0 { a.append(carry) }
+}
+
+/// `a /= d`, in place, returning the remainder.  The counterpart of the above,
+/// for the loop that peels digit chunks off a value on the way out.
+internal func _divideInPlace(_ a: inout [UInt], byLimb d: UInt) -> UInt {
+    precondition(d != 0, "division by zero")
+    var rem: UInt = 0
+    var i = a.count - 1
+    while 0 <= i {
+        (a[i], rem) = d.dividingFullWidth((high: rem, low: a[i]))
+        i -= 1
+    }
+    _normalize(&a)
+    return rem
+}
+
 /// Below this many limbs, schoolbook multiplication beats Karatsuba's bookkeeping.
 internal let _karatsubaLimit = 40
 
@@ -203,29 +236,42 @@ internal func _shiftLeft(_ a: [UInt], _ k: Int) -> [UInt] {
 /// `a << k` where `a` is two's complement with `ext` above it, so the bits
 /// shifted in at the top are sign and not zero.
 internal func _shiftLeft(_ a: [UInt], signExtension ext: UInt, _ k: Int) -> [UInt] {
-    let (limbs, bits) = (k / UInt.bitWidth, k % UInt.bitWidth)
-    let n = a.count + limbs + 1
-    var r = [UInt](repeating: 0, count: n)
-    for i in 0 ..< n {
-        let j = i - limbs
-        let cur  = j     < 0 ? 0 : (j     < a.count ? a[j]     : ext)
-        let prev = j - 1 < 0 ? 0 : (j - 1 < a.count ? a[j - 1] : ext)
-        r[i] = bits == 0 ? cur : (cur << bits) | (prev >> (UInt.bitWidth - bits))
+    let (whole, bits) = (k / UInt.bitWidth, k % UInt.bitWidth)
+    // A whole number of limbs moves without touching a bit.
+    if bits == 0 {
+        var r = [UInt](repeating: 0, count: whole)
+        r.reserveCapacity(whole + a.count + 1)
+        r.append(contentsOf: a)
+        r.append(ext)
+        return r
     }
+    // Otherwise one pass, carrying each limb's displaced top bits into the next.
+    // The bounds and the bits == 0 test used to be inside the loop, which cost
+    // four branches per limb on the package's second-cheapest operation.
+    let inverse = UInt.bitWidth - bits
+    var r = [UInt](repeating: 0, count: a.count + whole + 1)
+    var carried: UInt = 0
+    for i in 0 ..< a.count {
+        r[i + whole] = (a[i] << bits) | carried
+        carried = a[i] >> inverse
+    }
+    r[a.count + whole] = (ext << bits) | carried
     return r
 }
 
 /// `a >> k`, arithmetically: `ext` fills in from the left.
 internal func _shiftRight(_ a: [UInt], signExtension ext: UInt, _ k: Int) -> [UInt] {
-    let (limbs, bits) = (k / UInt.bitWidth, k % UInt.bitWidth)
-    if a.count <= limbs { return [ext] }    // everything shifted out: 0 or -1
-    var r = [UInt](repeating: 0, count: a.count - limbs)
-    for i in 0 ..< r.count {
-        let j = i + limbs
-        let cur  = j     < a.count ? a[j]     : ext
-        let next = j + 1 < a.count ? a[j + 1] : ext
-        r[i] = bits == 0 ? cur : (cur >> bits) | (next << (UInt.bitWidth - bits))
+    let (whole, bits) = (k / UInt.bitWidth, k % UInt.bitWidth)
+    if a.count <= whole { return [ext] }    // everything shifted out: 0 or -1
+    let count = a.count - whole
+    if bits == 0 { return Array(a[whole ..< a.count]) }
+    let inverse = UInt.bitWidth - bits
+    var r = [UInt](repeating: 0, count: count)
+    for i in 0 ..< count - 1 {
+        r[i] = (a[i + whole] >> bits) | (a[i + whole + 1] << inverse)
     }
+    // only the last limb reaches past the end, where the sign extension lives
+    r[count - 1] = (a[a.count - 1] >> bits) | (ext << inverse)
     return r
 }
 
@@ -237,6 +283,24 @@ internal func _shiftRight(_ a: [UInt], signExtension ext: UInt, _ k: Int) -> [UI
 /// builds -- and going through `BinaryInteger`'s witnesses there cost an
 /// unspecialized call and a fresh array per iteration.  Same algorithm, in place.
 ///
+/// Binary GCD on single words, for the operands that fit in one -- which is
+/// every `Int`-sized pair, and is `BigRat`'s hot path since every rational
+/// reduces on construction.
+internal func _gcdLimb(_ a: UInt, _ b: UInt) -> UInt {
+    if a == 0 { return b }
+    if b == 0 { return a }
+    var (x, y) = (a, b)
+    let twos = Swift.min(x.trailingZeroBitCount, y.trailingZeroBitCount)
+    x >>= x.trailingZeroBitCount
+    y >>= y.trailingZeroBitCount
+    while x != y {
+        if x < y { swap(&x, &y) }
+        x -= y
+        x >>= x.trailingZeroBitCount
+    }
+    return x << twos
+}
+
 internal func _gcd(_ a: [UInt], _ b: [UInt]) -> [UInt] {
     if a.isEmpty { return b }
     if b.isEmpty { return a }
@@ -586,6 +650,10 @@ extension BigUInt : Strideable {
 
 extension BigUInt {
     public func greatestCommonDivisor(with other: BigUInt) -> BigUInt {
+        if limbs.count <= 1 && other.limbs.count <= 1 {
+            let g = _gcdLimb(limbs.first ?? 0, other.limbs.first ?? 0)
+            return BigUInt(normalized: g == 0 ? [] : [g])
+        }
         return BigUInt(normalized: _gcd(self.limbs, other.limbs))
     }
 

--- a/Sources/BigNum/Radix.swift
+++ b/Sources/BigNum/Radix.swift
@@ -1,0 +1,268 @@
+//
+//  Radix.swift -- text in and text out, without the arithmetic it does not need.
+//
+//  The generic versions in BigIntType.swift work for any conformer and are what
+//  a new type gets for free.  They also treat every radix the same way: peel off
+//  the largest chunk of digits that fits a limb, and multiply or divide the whole
+//  number by that chunk's base.  For radix 10 that is unavoidable.  For radix 16
+//  it is entirely unnecessary -- 16 is a power of two, so each digit *is* four
+//  bits of a limb and the conversion is bit shuffling.
+//
+//  Benchmarking made the cost visible.  Parsing 4096 bits of hex cost 61.5µs
+//  against Node's 1.08µs and CPython's 1.29µs, and the giveaway was internal:
+//  our hex parse cost the same as our *decimal* parse, when decimal has to do
+//  arithmetic and hex does not.  So:
+//
+//   *  Radix 2, 4, 8, 16 and 32 go through `_limbsFromDigits` and
+//      `_digitsFromLimbs`, which touch each digit once and never multiply.
+//   *  Every other radix keeps the chunked algorithm, but runs it on the limbs
+//      in place, so a parse is one allocation rather than one per chunk.
+//
+//  Both live here as concrete implementations on `BigUInt` and `BigInt`, which
+//  take precedence over the generic ones.  Nothing about the protocol changes.
+//
+
+// MARK: - digit tables
+
+private let _lowerDigits = Array("0123456789abcdefghijklmnopqrstuvwxyz".utf8)
+private let _upperDigits = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".utf8)
+
+/// How many bits one digit of `radix` is worth, when the answer is a whole
+/// number of bits.  Nil for every other radix, which is what selects the
+/// arithmetic path.
+@inline(__always) internal func _bitsPerDigit(_ radix: Int) -> Int? {
+    switch radix {
+    case 2:  return 1
+    case 4:  return 2
+    case 8:  return 3
+    case 16: return 4
+    case 32: return 5
+    default: return nil
+    }
+}
+
+// MARK: - power-of-two radices, which are pure bit shuffling
+
+/// Fills limbs straight from the digits, least significant first.  `bits` need
+/// not divide the limb width: a digit that straddles a limb boundary has its low
+/// part written and its high part carried into the next limb.
+internal func _limbsFromDigits(_ chars: [UInt8], radix: Int, bits: Int) -> [UInt]? {
+    var limbs = [UInt]()
+    limbs.reserveCapacity((chars.count * bits) / UInt.bitWidth + 1)
+    var acc: UInt = 0
+    var used = 0
+    var i = chars.count - 1
+    while 0 <= i {
+        guard let d = _digitValue(chars[i]), d < radix else { return nil }
+        let v = UInt(d)
+        acc |= v << used
+        used += bits
+        if used >= UInt.bitWidth {
+            limbs.append(acc)
+            used -= UInt.bitWidth
+            // whatever of this digit did not fit starts the next limb
+            acc = used > 0 ? v >> (bits - used) : 0
+        }
+        i -= 1
+    }
+    if acc != 0 { limbs.append(acc) }
+    _normalize(&limbs)
+    return limbs
+}
+
+/// And back out.  Each digit is `bits` bits at a known offset, so this reads
+/// them off with shifts and never divides.
+internal func _digitsFromLimbs(_ limbs: [UInt], radix: Int, bits: Int,
+                               uppercase: Bool) -> String {
+    guard let top = limbs.last else { return "0" }
+    let significant = (limbs.count - 1) * UInt.bitWidth
+                        + (UInt.bitWidth - top.leadingZeroBitCount)
+    let count = (significant + bits - 1) / bits
+    let table = uppercase ? _upperDigits : _lowerDigits
+    let mask = UInt(radix - 1)
+    var out = [UInt8](repeating: 0, count: count)
+    for k in 0 ..< count {
+        let offset = k * bits
+        let index = offset / UInt.bitWidth
+        let shift = offset % UInt.bitWidth
+        var v = limbs[index] >> shift
+        // a digit that straddles the boundary takes its high bits from above
+        if shift + bits > UInt.bitWidth && index + 1 < limbs.count {
+            v |= limbs[index + 1] << (UInt.bitWidth - shift)
+        }
+        out[count - 1 - k] = table[Int(v & mask)]
+    }
+    return String(decoding: out, as: UTF8.self)
+}
+
+// MARK: - every other radix, chunked but in place
+
+/// The chunked parse, with the multiply-and-add done on the limbs rather than
+/// through `*` and `+` on the whole type.  Same algorithm as the generic
+/// version; one allocation instead of three per chunk.
+internal func _limbsFromChunkedDigits(_ chars: [UInt8], radix: Int) -> [UInt]? {
+    let (digits, base) = _radixChunk(radix)
+    var limbs = [UInt]()
+    limbs.reserveCapacity(chars.count / digits + 2)
+    // Take the short chunk first so every later one is exactly `digits` wide.
+    var i = 0
+    var head = chars.count % digits
+    if head == 0 { head = digits }
+    while i < chars.count {
+        let n = i == 0 ? head : digits
+        var chunk: UInt = 0
+        for _ in 0 ..< n {
+            guard let d = _digitValue(chars[i]), d < radix else { return nil }
+            chunk = chunk * UInt(radix) + UInt(d)
+            i += 1
+        }
+        if limbs.isEmpty {
+            if chunk != 0 { limbs.append(chunk) }
+        } else {
+            _multiplyInPlace(&limbs, byLimb: base, adding: chunk)
+        }
+    }
+    return limbs
+}
+
+/// The chunked render, dividing the limbs in place instead of building a new
+/// value per chunk, and writing digits into one byte buffer instead of building
+/// and concatenating a `String` per chunk.
+internal func _chunkedDigitsFromLimbs(_ limbs: [UInt], radix: Int,
+                                      uppercase: Bool) -> String {
+    if limbs.isEmpty { return "0" }
+    let (digits, base) = _radixChunk(radix)
+    var v = limbs
+    var chunks = [UInt]()
+    chunks.reserveCapacity(limbs.count * 2)
+    while !v.isEmpty {
+        chunks.append(_divideInPlace(&v, byLimb: base))
+    }
+    let table = uppercase ? _upperDigits : _lowerDigits
+    let r = UInt(radix)
+    // Every chunk but the most significant is exactly `digits` wide, zeros
+    // included, so the total length is known before a byte is written.
+    let top = chunks[chunks.count - 1]
+    var topLength = 0
+    var t = top
+    while t != 0 { topLength += 1 ; t /= r }
+    if topLength == 0 { topLength = 1 }
+    var out = [UInt8](repeating: table[0], count: topLength + (chunks.count - 1) * digits)
+    var pos = out.count - 1
+    // Radix 10 gets its own copy of the loop purely so that the divisor is a
+    // literal: the compiler turns `% 10` and `/ 10` into a multiply and a shift,
+    // where a runtime `r` has to be a real division on every digit.  `description`
+    // is the most-called conversion in the package, so it earns the duplication.
+    if radix == 10 {
+        for k in 0 ..< chunks.count - 1 {
+            var x = chunks[k]
+            for _ in 0 ..< digits {
+                out[pos] = table[Int(x % 10)]
+                x /= 10
+                pos -= 1
+            }
+        }
+        var x = top
+        while x != 0 {
+            out[pos] = table[Int(x % 10)]
+            x /= 10
+            pos -= 1
+        }
+    } else {
+        for k in 0 ..< chunks.count - 1 {
+            var x = chunks[k]
+            for _ in 0 ..< digits {
+                out[pos] = table[Int(x % r)]
+                x /= r
+                pos -= 1
+            }
+        }
+        var x = top
+        while x != 0 {
+            out[pos] = table[Int(x % r)]
+            x /= r
+            pos -= 1
+        }
+    }
+    return String(decoding: out, as: UTF8.self)
+}
+
+// MARK: - the text, before any of that
+
+/// Strips the sign and hands back the digits as bytes.  Nil if the text is not
+/// a number at all; the digits themselves are validated during conversion.
+@inline(__always)
+internal func _splitSign<S:StringProtocol>(_ text: S) -> (digits: [UInt8], negative: Bool)? {
+    var bytes = Array(text.utf8)
+    var negative = false
+    if let first = bytes.first {
+        if first == UInt8(ascii: "-") { negative = true ; bytes.removeFirst() }
+        else if first == UInt8(ascii: "+") { bytes.removeFirst() }
+    }
+    return bytes.isEmpty ? nil : (bytes, negative)
+}
+
+@inline(__always) internal func _digitValue(_ c: UInt8) -> Int? {
+    switch c {
+    case 0x30 ... 0x39: return Int(c - 0x30)        // 0-9
+    case 0x41 ... 0x5A: return Int(c - 0x41) + 10   // A-Z
+    case 0x61 ... 0x7A: return Int(c - 0x61) + 10   // a-z
+    default:            return nil
+    }
+}
+
+/// Digits to limbs, by whichever of the two routes the radix allows.
+internal func _limbs<S:StringProtocol>(from text: S, radix: Int) -> (limbs: [UInt], negative: Bool)? {
+    precondition(2 <= radix && radix <= 36, "radix must be in 2...36, not \(radix)")
+    guard let (digits, negative) = _splitSign(text) else { return nil }
+    let limbs = _bitsPerDigit(radix).map { _limbsFromDigits(digits, radix: radix, bits: $0) }
+                  ?? _limbsFromChunkedDigits(digits, radix: radix)
+    guard let l = limbs else { return nil }
+    return (l, negative)
+}
+
+/// Limbs to digits, likewise.  `limbs` is an unsigned magnitude.
+internal func _string(fromMagnitude limbs: [UInt], radix: Int, uppercase: Bool) -> String {
+    precondition(2 <= radix && radix <= 36, "radix must be in 2...36, not \(radix)")
+    if limbs.isEmpty { return "0" }
+    if let bits = _bitsPerDigit(radix) {
+        return _digitsFromLimbs(limbs, radix: radix, bits: bits, uppercase: uppercase)
+    }
+    return _chunkedDigitsFromLimbs(limbs, radix: radix, uppercase: uppercase)
+}
+
+// MARK: - and the two concrete types
+
+extension BigUInt {
+    public init?<S:StringProtocol>(_ text: S, radix: Int = 10) {
+        guard let (limbs, negative) = _limbs(from: text, radix: radix) else { return nil }
+        if negative { return nil }          // an unsigned type refuses a sign
+        self.init(normalized: limbs)
+    }
+    public init?(_ description: String) {
+        self.init(description, radix: 10)
+    }
+    public func toString(radix: Int = 10, uppercase: Bool = false) -> String {
+        return _string(fromMagnitude: self.limbs, radix: radix, uppercase: uppercase)
+    }
+    public var description: String {
+        return self.toString(radix: 10, uppercase: false)
+    }
+}
+
+extension BigInt {
+    public init?<S:StringProtocol>(_ text: S, radix: Int = 10) {
+        guard let (limbs, negative) = _limbs(from: text, radix: radix) else { return nil }
+        self.init(magnitude: limbs, negative: negative)
+    }
+    public init?(_ description: String) {
+        self.init(description, radix: 10)
+    }
+    public func toString(radix: Int = 10, uppercase: Bool = false) -> String {
+        let body = _string(fromMagnitude: self.magnitudeLimbs, radix: radix, uppercase: uppercase)
+        return isNegative ? "-" + body : body
+    }
+    public var description: String {
+        return self.toString(radix: 10, uppercase: false)
+    }
+}


### PR DESCRIPTION
Re-runs the cross-language benchmark against `/usr/bin/ruby` — the copy macOS ships, since that is the Ruby a Mac has without being asked — then fixes the five things the first run found. `RUBY=/path/to/ruby` overrides it, and the harness now reports which interpreter it got.

## What it bought

Speedups of this branch over the code that was measured:

| operation | 64 bits | 256 | 1024 | 4096 |
|---|---:|---:|---:|---:|
| `init(radix: 16)` | **9.4×** | **16.2×** | **26.2×** | **33.1×** |
| `init(radix: 10)` | **11.6×** | **18.8×** | **25.9×** | **20.5×** |
| `description` | **2.4×** | **5.4×** | **5.1×** | **2.1×** |
| `-` | **2.5×** | **2.4×** | **2.4×** | **2.2×** |
| `*` | **4.3×** | 1.02× | 0.99× | 1.05× |
| `gcd` | **6.6×** | 0.94× | 1.12× | 0.97× |

**Radix conversion** is a new file, [Radix.swift](Sources/BigNum/Radix.swift). Powers of two need no arithmetic at all — 16 is four bits, so a hex digit *is* half a limb — but the parser ran the same chunked multiply-and-add it uses for decimal. The giveaway was internal rather than comparative: hex cost the same as decimal, when decimal has to multiply and hex does not. Radices 2, 4, 8, 16 and 32 now pack bits directly in both directions; every other radix keeps the chunked algorithm but runs it on the limbs in place, one allocation instead of one per chunk. `description` writes one byte buffer instead of building and concatenating a `String` per chunk.

**`-` was `lhs + (-rhs)`** — three passes and three allocations, where two's complement subtraction is `lhs + ~rhs + 1` in one of each.

**`*` and `gcd` had no small-operand path**, and my first attempt at one never fired, which is the detail worth a reviewer's attention: it tested limb *count*. Count is the wrong question — a positive value with its top bit set carries a clear sign limb, so 2^63 is two limbs wide while its magnitude is one, and the benchmark's 64-bit inputs all have their top bit set. Testing the magnitude instead (`singleLimbMagnitude`) routes every `Int`-sized pair through `multipliedFullWidth` and a word-sized binary GCD, in registers. `*` at 64 bits went 233 ns → 54 ns.

## Two attempts that were not worth it

Recorded in Benchmark.md so nobody repeats them: the shift primitives had four branches per limb in their inner loops, and hoisting those out bought 1.0–1.5×. The radix-10 digit specialisation moved `description` at 64 bits by about 5%. **Every gain of any size came from removing an allocation or an algorithm, never from tightening a loop.**

## Where the comparison stands

Medians over the shared operations; greater than 1 means swift-bignum is faster:

| | 64 bits | 256 | 1024 | 4096 |
|---|---:|---:|---:|---:|
| python | 0.35× | 0.90× | **1.19×** | **1.73×** |
| ruby 2.6 | 0.43× | **1.29×** | **2.07×** | **2.08×** |
| node | 0.15× | 0.39× | 0.36× | 0.50× |

Faster than CPython above 256 bits and than macOS's Ruby from 256 up, where before it was 1024 and never. Still behind V8 everywhere, and behind all three on 64-bit operands.

That last gap is not the arithmetic. **Every operation returning a new value allocates an array for it** — 40–60 ns before any work — against a measured 11 ns `baseline` for a call and a fold with no allocation. CPython and Ruby pay ~130 ns of interpreter loop per iteration but hand small integers out of a free list, so on a 64-bit operand they are beating our allocator rather than our algorithms. Closing it means storing small values inline instead of in a heap array: a change to the storage type, larger than anything here, and not attempted.

## Verification

Each rewrite is checked against the definition it replaced, not only against the existing suite:

- `-` against `lhs + (-rhs)` over every pair of 113 edge and random values
- `*` by commutativity, division round-trip, and distributivity over both `+` and `-`
- `gcd` against an independent Euclid on 5,475 word pairs, plus divisor-and-maximal above them
- the rewritten shifts against `x * 2^k` and floored `x / 2^k`, including negatives — where a shift rewrite goes wrong
- radix round-trips for all 35 radices, uppercase consistency, and agreement with `String(_:radix:)`; all previous rejections still rejected

73 tests pass, all six playground pages still compile and run, and all 15 prose numbers in Benchmark.md are verified against the raw TSVs by script rather than transcribed.

## Also

`bench.rb` reported Apple's Ruby as "GMP possible" when its `configure_args` mentions GMP neither way — a label I had written. It now says exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)