### PR TITLE
Document where this BigInt is not attaswift's, in CAVEAT.md

### DIFF
--- a/CAVEAT.md
+++ b/CAVEAT.md
@@ -1,0 +1,190 @@
+# Caveat
+
+Up to version 5.x this package got `BigInt` and `BigUInt` from
+[attaswift/BigInt]. It now has its own, and they are **not** a drop-in
+replacement. Most code moves across untouched; this is the list of what does not,
+so you can find out by reading rather than by compiling.
+
+Nothing here is a plan. These are differences, some of them deliberate, and the
+document exists because "mostly compatible" is not a useful thing to be told.
+
+## How this was measured
+
+Every public member attaswift/BigInt declares was written out as a use of *our*
+`BigInt`/`BigUInt` — 106 usages in all — and handed to the compiler. **50 compile
+and 56 do not.** What follows is the 56, grouped by what it would take to close
+them, plus the two behavioural differences that compile fine and then do
+something else.
+
+The count is of usages, not of features: several members appear twice because
+attaswift declares them on both types.
+
+## Behaviour: compiles, differs
+
+These are the dangerous ones, because nothing tells you.
+
+### `>>` on a negative value
+
+| value | `Int` | swift-bignum | attaswift |
+|---:|---:|---:|---:|
+| -3 | -2 | -2 | **-1** |
+| -5 | -3 | -3 | **-2** |
+| -1025 | -513 | -513 | **-512** |
+
+`BinaryInteger` specifies an arithmetic shift, which floors. That is what `Int`
+does, what this package does, and what JavaScript, Python and Ruby do.
+attaswift shifts the magnitude and keeps the sign, which truncates toward zero.
+Across the seven values in [Benchmark.md](Benchmark.md), we match `Int` 7 times
+and attaswift 3.
+
+**If your code right-shifts negative numbers, the answers will change** — to the
+ones `Int` would have given.
+
+### `Codable`
+
+A `BigInt` encodes as a single base-16 string; attaswift encodes sign and words.
+Archives written by 5.x will not decode. Readable in a JSON dump was worth more
+than compatibility with a format nothing else reads, but if you have stored data,
+that is a migration and not a recompile.
+
+## Missing: the same capability under another name
+
+Eleven members — 22 of the 56 usages — all of which we can already do. Nothing is stopping these from
+being added; they are not, because each one is a name we would have to keep.
+
+| attaswift | here | difference |
+|---|---|---|
+| `power(_:modulus:)` | `power(_:mod:)` | the argument label |
+| `isStrongProbablePrime(_:)` | `millerRabinTest(base:)` | the name |
+| `inverse(_:) -> Self?` | `power(-1, mod:)` | **ours traps where attaswift returns nil.** The `nil` case is computed internally and not exposed |
+| `isPrime(rounds:) -> Bool` | `isPrime: Bool?` | a method taking a round count, against a property that returns `nil` when it cannot prove the answer. See [BigInt.md](BigInt.md#primality) |
+| `modulus(_:)` | `((x % m) + m) % m` | Euclidean modulus, always non-negative; ours is truncating, so it takes the dividend's sign. That replacement is checked against attaswift over 3000 values |
+| `debugDescription` | `description` | not `CustomDebugStringConvertible` |
+| `playgroundDescription` | — | not `CustomPlaygroundDisplayConvertible` |
+| `&<<`, `&>>` | `<<`, `>>` | masking shifts, which at arbitrary precision are the plain ones — there is no width to mask against |
+| `init(words:)` | `init(_:)` from any `BinaryInteger` | no construction from a word sequence |
+| `let x: BigInt = "123"` | `BigInt("123")!` | not `ExpressibleByStringLiteral`. The literal form traps on nonsense; the initializer returns nil |
+| `leadingZeroBitCount` | — | attaswift counts within its word storage. For an unbounded value there is no width to count from, so it would have to mean "within `bitWidth`" and that is a different question than the one `FixedWidthInteger` answers |
+
+## Missing: capability we do not have
+
+### Random values — 6 usages
+
+```swift
+BigUInt.randomInteger(withMaximumWidth: 1024)
+BigUInt.randomInteger(withExactWidth: 1024)
+BigUInt.randomInteger(lessThan: n)
+// and each with `using: &generator`
+```
+
+There is no equivalent. Build one from `SystemRandomNumberGenerator` and
+`init(words:)`… which is also missing, so from `<<` and `|` over `UInt.random(in:)`.
+
+### Byte serialization — 10 usages
+
+```swift
+u.serialize() -> Data
+BigUInt(data)
+u.serializeToBuffer() -> UnsafeRawBufferPointer
+BigUInt(someRawBufferPointer)
+BigInt(exactly: someDecimal)
+BigInt(truncating: someDecimal)
+```
+
+Big-endian bytes, in both directions, on both types — four member names, so eight
+usages — plus the two `Decimal` initializers. All of it needs Foundation, and `Sources/BigNum` imports Foundation
+nowhere — the whole package is the standard library and the platform's libm. That
+is the reason, and it is a real cost: there is no supported way to get a `BigInt`
+in or out as bytes. `toString(radix: 16)` and `init?(_:radix:)` round-trip
+losslessly and are fast, but they are text.
+
+## Missing: API that publishes a representation
+
+Eighteen usages, and the ones least likely to change. attaswift is
+sign-and-magnitude over an array of words, and says so in its API. This package
+is two's complement over `[UInt]` limbs, and does not.
+
+### The sign
+
+```swift
+x.sign              // BigInt.Sign, .plus or .minus
+BigInt.Sign.self
+BigInt(sign: .minus, magnitude: BigUInt(5))
+```
+
+A two's-complement value has no separate sign to return. Use `isNegative`,
+`signum()`, `magnitude`, or `< 0` — and note that a sign-and-magnitude type has to
+legislate away negative zero, while this one cannot represent it.
+
+### The words
+
+```swift
+u[0]                // subscript(Int) -> Word
+u[bitAt: 3]         // subscript(bitAt:) -> Bool
+u.count             // how many words
+BigUInt.Word        // the word type
+```
+
+`words` is there, and **the two libraries agree on it, negatives included** —
+`BinaryInteger` specifies two's complement, so attaswift synthesizes from its sign
+and magnitude what this package stores directly. Checked over 2500 values. Code
+reading `words` ports unchanged.
+
+What is not there is indexed access, bit access, a word count, or a public name for
+the word type. Exposing them would fix the storage in place, and `words` plus
+`bitWidth` answer most of what they were for.
+
+### The word-level operations — 9 members, 10 usages
+
+```swift
+u.multiplied(by: v)                        // and multiplied(byWord:)
+u.multiply(byWord: w)
+u.multiplyAndAdd(v, w, shiftedBy: k)
+u.subtracting(v)                           // and subtracting(_:shiftedBy:)
+u.subtract(v, shiftedBy: k)
+u.subtractingReportingOverflow(v)
+u.subtractReportingOverflow(v, shiftedBy: k)
+u.decrement(shiftedBy: k)
+```
+
+attaswift's internals, made public: in-place mutation, a shift built into the
+operand, and overflow reporting on a type that cannot overflow. The equivalents
+here are `*`, `-`, `<<` and the compound assignments.
+
+**`shiftedBy` counts words, not bits**, so the shifted forms translate as
+`x - (y << (k * UInt.bitWidth))` — the obvious reading of `y << k` is wrong by a
+factor of 64. Checked against attaswift over 2000 cases, as is `multiplied(by:)`
+being `*`.
+
+`subtractingReportingOverflow` has no counterpart, and this one is a real hole
+rather than a rename. Subtracting past zero traps here, as it does for `UInt`.
+attaswift instead **reports**: `BigUInt(3).subtractingReportingOverflow(BigUInt(10))`
+returns `(18446744073709551609, true)` — wrapped into one word, with the flag set,
+and no trap. Code relying on that flag has to become a `>=` test before the
+subtraction; there is nothing here that returns instead of trapping.
+
+## What does move across
+
+For balance, since the list above is longer than it feels: all 50 of these
+compile unchanged.
+
+* Every arithmetic, comparison, bitwise and shift operator, and their compound
+  forms
+* `quotientAndRemainder(dividingBy:)`, `isMultiple(of:)`, `negate()`, `signum()`,
+  `magnitude`, `isZero`, `isSigned`
+* `power(_:)` with an `Int` exponent, `squareRoot()`,
+  `greatestCommonDivisor(with:)`
+* `words`, `Words`, `Magnitude`, `bitWidth`, `trailingZeroBitCount`
+* `Codable` (the protocol; see the format caveat above), `Hashable`, `Comparable`
+* The whole `Strideable` surface, including `advanced(by:)`, `distance(to:)`,
+  `Stride`, and `stride(from:to:by:)`
+* `String(_:radix:uppercase:)` and `init?(_:radix:)`
+* Every `BinaryInteger` conversion — plain, `exactly:`, `clamping:`,
+  `truncatingIfNeeded:` — and both `BinaryFloatingPoint` directions
+
+And a good deal that attaswift has no answer for: `isPrime`/`isSurelyPrime` and
+the primality family, `power(_:mod:)` with an exponent as wide as the modulus,
+`over(_:)`, the rational and floating-point types, and all of it on the built-in
+integers as well. See the [README](README.md).
+
+[attaswift/BigInt]: https://github.com/attaswift/BigInt

--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ the `BigNum` module is built, then open the playground.
   truncation, parsing
 * [Benchmark.md](Benchmark.md) — `BigInt` against attaswift/BigInt, JavaScript,
   Python and Ruby, and the one place any of them disagree
+* [CAVEAT.md](CAVEAT.md) — every way this `BigInt` is *not* a drop-in replacement
+  for attaswift's, measured by compiling all 106 of its public members against
+  ours
 
 # Prerequisite
 
@@ -269,9 +272,15 @@ Swift 6 or 5, macOS or Linux.
 * Versions before that depended on [dankogai/swift-floatingpoint] for the
   `FloatingPointMath` protocols, replaced by `ElementaryFunctions`.
 
-Code written against either former dependency keeps compiling: the protocol
-requirement sets are unchanged, and `BigInt` and `BigUInt` keep the names and the
-API attaswift gave them. Two deliberate breaks:
+Code written against swift-numerics keeps compiling — the protocol requirement
+sets are unchanged. Code written against attaswift's `BigInt` mostly does, but not
+entirely: of its 106 public members, 50 compile against ours and 56 do not.
+**[CAVEAT.md](CAVEAT.md) lists all of them**, along with the two differences that
+compile and then behave differently. The largest groups are attaswift's random
+generators, its `Data` serialization, and the API through which it publishes its
+sign-and-magnitude word representation.
+
+Two of those differences are worth repeating here:
 
 * **`Codable`** — a `BigInt` now encodes as a base-16 string rather than
   attaswift's sign-and-words form, so archives written by 5.x will not decode.


### PR DESCRIPTION
Documentation only. **Nothing under `Sources/` or `Tests/` changes** — the instruction was to describe the differences, not chase them. 73 tests still pass, untouched.

## What was measured

Every public member attaswift/BigInt declares was written out as a use of *our* `BigInt`/`BigUInt` — **106 usages — and handed to the compiler. 50 compile, 56 do not.** [CAVEAT.md](CAVEAT.md) is those 56, grouped by what closing them would cost, since the group matters more than the count:

- **Behaviour that compiles and then differs**, first because nothing warns you: `>>` on negatives (we match `Int`, attaswift doesn't) and the `Codable` format.
- **Same capability under another name** — 11 members, 22 usages, each with the replacement to write: `power(_:modulus:)`, `isStrongProbablePrime`, `inverse`, `modulus`, `&<<`/`&>>`, string literals, `init(words:)`, `debugDescription`, `playgroundDescription`, `leadingZeroBitCount`, and `isPrime` — which is ours deliberately, a `Bool?` property against their `Bool` method.
- **Capability absent** — the six random generators, and ten usages of byte serialization. The latter all need Foundation, which `Sources/BigNum` imports nowhere. That is the reason and it is a real cost: there is then no supported way to get a `BigInt` in or out as bytes.
- **API that publishes a representation** — eighteen usages: `sign`/`Sign`/`init(sign:magnitude:)`, the word subscripts, `count`, `Word`, and the nine word-level operations. attaswift is sign-and-magnitude over words and says so in its API; this is two's complement and does not.

Then what does port, since the missing list reads longer than it is.

## Two corrections the verification forced

The replacements the document recommends are checked against attaswift itself rather than asserted, and two were wrong on the first pass:

- **`shiftedBy` counts words, not bits.** I had written the stand-in for `subtracting(_:shiftedBy:)` as `x - (y << k)`; it is `x - (y << (k * UInt.bitWidth))` — wrong by a factor of 64. Found by trapping my own test on an underflow.
- **attaswift's `subtractingReportingOverflow` does not trap**, which I had claimed by inference from a different method. It returns `(18446744073709551609, true)` for `3 - 10` — wrapped into one word, flag set. So it is a real hole rather than a rename, and porting code needs a `>=` test before the subtraction.

Verified positively over a few thousand values each: `((x % m) + m) % m` matches `modulus(_:)` including for negatives, `multiplied(by:)` is `*`, and **`words` agrees between the two libraries for negatives too** — `BinaryInteger` specifies two's complement, so attaswift synthesizes what this package stores, and code reading `words` ports unchanged.

Every count in the document is checked against the measurement by script. Two were wrong before that check: serialization is 10 usages rather than 8, and the representation group 18 rather than 16.

## For the reviewer

The three decisions I flagged earlier are recorded in the document as *reasons*, not as pending work — Foundation for `Data`, the `isPrime` name collision, and whether to publish a limb representation. If any of them should change, that is a separate PR with its own tests.

The compile harness that produced these numbers lives in my scratch space rather than the repo. Happy to add it as a test target if you want the 50/56 split enforced rather than merely recorded — it would fail the day attaswift adds a member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)