### PR TITLE
Record the memoised-constant data race in CAVEAT.md

### DIFF
--- a/CAVEAT.md
+++ b/CAVEAT.md
@@ -47,6 +47,43 @@ Archives written by 5.x will not decode. Readable in a JSON dump was worth more
 than compatibility with a format nothing else reads, but if you have stored data,
 that is a migration and not a recompile.
 
+### Thread safety
+
+`BigRat` and `BigFloat` memoise π/4, e, √2, ln 2 and ln 10 per precision in
+`static var`s, and their `precision`, `roundingRule` and `expLimit` are settable
+statics too. **None of it is synchronised.** Two threads asking for a
+transcendental at the same time can read and write one of those memos at once,
+and because the stored value owns a reference-counted array, the failure mode is
+not a wrong answer but a corrupted heap.
+
+It is intermittent and it does happen: one Linux CI run of this very pull request
+aborted with `SIGABRT` and passed on re-run, and the thread sanitiser, given a
+concurrent stress test, names the race — `static BigRational.E.setter`. It
+reproduces perhaps one run in ten, which is why it went unnoticed.
+
+Scope, which is narrower than it sounds:
+
+* **`BigInt` and `BigUInt` are unaffected.** They have no mutable static state at
+  all — checked file by file — so integer code is as safe concurrently as any
+  other value type.
+* **`BigRat` and `BigFloat` arithmetic** (`+`, `*`, `/`, comparison, conversion)
+  is also unaffected. Only the transcendental functions and `precision` touch the
+  shared statics.
+* So the exposure is concurrent calls to `exp`, `log`, `pow`, `sqrt`, the
+  trigonometrics, `pi`, or assignment to `precision`.
+
+Until it is fixed, confine those to one thread or serialise around them.
+
+**attaswift has no mutable static state anywhere**, so this is a way code that was
+thread-safe against it can stop being thread-safe here. Both libraries declare
+their types `Sendable`; ours is telling the truth about the values and not about
+the constants beside them.
+
+This is a defect rather than a design difference, and unlike everything else in
+this document it should be fixed rather than documented. It is written down here
+because it was found while checking the rest, and because a known crash deserves
+to be findable before it is fixed.
+
 ## Missing: the same capability under another name
 
 Eleven members — 22 of the 56 usages — all of which we can already do. Nothing is stopping these from


### PR DESCRIPTION
Follow-up to #21, which was merged while I was still investigating its CI failure.

## The CI failure was transient — the cause was not

The Linux job on #21 aborted with `SIGABRT` and **passed on re-run**, so that PR is green. But #21 changed only two markdown files, and the identical code had passed as #20, so "flaky" needed an explanation rather than a shrug.

`BigRat` and `BigFloat` memoise π/4, e, √2, ln 2 and ln 10 per precision in unsynchronised `static var`s, and their `precision`, `roundingRule` and `expLimit` are settable statics as well. Two threads asking for a transcendental at once can read and write one of those memos simultaneously, and because the stored value owns a reference-counted array the failure mode is **a corrupted heap, not a wrong answer** — which is exactly how an intermittent `SIGABRT` under a parallel test runner arises, glibc's abort being how heap corruption surfaces.

## Confirmed, not assumed

A concurrent stress test under the thread sanitiser names the race: `static BigRational.E.setter`. It took several attempts — roughly one run in ten — which is why it has gone unnoticed, and why the whole suite under TSan and three local release runs were all clean.

Worth noting for anyone re-checking: the race TSan named is between two library-internal accesses. The synthetic write in my stress test was to a *different* constant (`BigFloat.SQRT2`), so the report is not an artefact of the test racing on the library's behalf.

## Scope, checked file by file

Narrower than it sounds:

- **`BigInt` and `BigUInt` are unaffected** — `BigInt.swift`, `BigUInt.swift`, `Radix.swift`, `Primality.swift` and `BigIntType.swift` declare no mutable static state at all.
- **`BigRat`/`BigFloat` arithmetic is unaffected** — only the transcendentals and `precision` touch the shared statics.
- The exposure is concurrent calls to `exp`, `log`, `pow`, `sqrt`, the trigonometrics, `pi`, or assignment to `precision`.

## Why it belongs in CAVEAT.md

On its own terms, not just as a note-to-self: **attaswift has no mutable static state anywhere**, so this is a way code that was thread-safe against it stops being thread-safe here. Both libraries declare their types `Sendable`; ours is telling the truth about the values and not about the constants beside them.

The section says plainly that this one is a **defect to fix rather than a difference to live with** — unlike everything else in that document.

## What this PR does not do

Documentation only, per the standing instruction for CAVEAT.md. Fixing it needs either a portable lock (no package dependencies available, and Windows has no pthreads) or a restructured cache — and the obvious restructuring, computing each constant once at a generous precision and truncating down, could shift documented digit strings in their last bits. Those are design questions for their own PR.

73 tests pass; nothing under `Sources/` or `Tests/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)