### PR TITLE
Add the no-argument .random(), and stop rejecting power-of-two bounds

### DIFF
--- a/BigInt.md
+++ b/BigInt.md
@@ -457,6 +457,23 @@ UInt64.random(withExactWidth: 64)
 Int8.random(withMaximumWidth: 100)          // traps: 100 bits is not an Int8
 ```
 
+And there `random()` takes no arguments at all, meaning the whole range:
+
+```swift
+Int.random()                                // Int.min ... Int.max
+UInt8.random()                              // 0 ... 255
+```
+
+It is defined as `random(from: Self.min, to: Self.max)` and *is* that call, so a
+seeded generator gives the same value through either spelling. **`BigInt` and
+`BigUInt` have no `random()`** — an unbounded type has no `min` or `max` for it to
+mean anything against, so the no-argument form exists exactly where the type is
+bounded.
+
+A whole fixed-width range is a span of 2^bitWidth, a power of two, and a
+power-of-two bound is already uniform at one bit fewer — so that path skips the
+rejection step rather than throwing away half of its draws.
+
 The standard library's `Int.random(in: 1...10)` is untouched and remains the
 idiomatic spelling for a fixed-width range. These exist so generic code can say
 `T.random(...)` for any integer this package touches, `BigInt` included.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Int(2).power(10)                        // 1024
 UInt8(200).nextPrime                    // 211
 Int(2).power(1024, mod: 1_000_000_007)  // 812734592 -- no overflow, ever
 Int.random(from: -100, to: 100)         // and .random, closed at both ends
+Int.random()                            // ... or the whole range, min through max
 ```
 
 Each widens to `BigInt`, computes there, and comes back — so where the answer

--- a/Sources/BigNum/Random.swift
+++ b/Sources/BigNum/Random.swift
@@ -64,12 +64,31 @@ internal func _randomLimbs<R:RandomNumberGenerator>(lessThan limit: [UInt],
     precondition(!limit.isEmpty, "random(lessThan: 0) has nothing to return")
     let top = limit[limit.count - 1]
     let width = (limit.count - 1) * UInt.bitWidth + (UInt.bitWidth - top.leadingZeroBitCount)
-    // Rejection, not remainder: a draw of exactly `width` bits lands below the
-    // limit better than half the time, so this returns quickly and evenly.
+    // A power of two is every value of `width - 1` bits and nothing else, so the
+    // draw is already uniform and rejection would only throw away half of them.
+    // `random()` over a whole fixed-width range lands here every time, its span
+    // being 2^bitWidth exactly.
+    if _isPowerOfTwo(limit) {
+        return _randomLimbs(bits: width - 1, using: &g)
+    }
+    // Otherwise rejection, not remainder: a draw of exactly `width` bits lands
+    // below the limit better than half the time, so this returns quickly and
+    // evenly.
     while true {
         let candidate = _randomLimbs(bits: width, using: &g)
         if _compare(candidate, limit) < 0 { return candidate }
     }
+}
+
+/// Whether exactly one bit is set across all the limbs.
+@inline(__always) internal func _isPowerOfTwo(_ limbs: [UInt]) -> Bool {
+    var seen = false
+    for limb in limbs {
+        if limb == 0 { continue }
+        if seen || limb & (limb - 1) != 0 { return false }
+        seen = true
+    }
+    return seen
 }
 
 // MARK: - BigUInt
@@ -208,6 +227,21 @@ extension FixedWidthInteger {
     public static func random<R:RandomNumberGenerator>(from lower: Self, to upper: Self,
                                                        using generator: inout R) -> Self {
         return Self(BigInt.random(from: BigInt(lower), to: BigInt(upper), using: &generator))
+    }
+
+    /// A uniform value across the type's whole range, which is to say
+    /// `random(from: Self.min, to: Self.max)` -- and it is exactly that, so the
+    /// two give the same value from the same seeded generator.
+    ///
+    /// There is deliberately no `BigInt.random()` or `BigUInt.random()`: an
+    /// unbounded type has no `min` or `max` for this to mean anything against.
+    /// `random()` exists precisely where the type is bounded.
+    public static func random<R:RandomNumberGenerator>(using generator: inout R) -> Self {
+        return random(from: Self.min, to: Self.max, using: &generator)
+    }
+    public static func random() -> Self {
+        var g = SystemRandomNumberGenerator()
+        return random(using: &g)
     }
 
     public static func random(withMaximumWidth width: Int) -> Self {

--- a/Tests/BigNumTests/RandomTests.swift
+++ b/Tests/BigNumTests/RandomTests.swift
@@ -253,6 +253,112 @@ import Testing
         #expect(sawTop, "UInt64.max must be reachable")
     }
 
+    // MARK: - the no-argument form
+
+    /// `random()` is defined as `random(from: .min, to: .max)`, so it is worth
+    /// asserting that it *is* that and not merely distributed like it: the same
+    /// seed must give the same value through either spelling.
+    @Test func randomIsTheFullRange() {
+        var a = Seeded(seed: 11), b = Seeded(seed: 11)
+        for _ in 0 ..< 50 {
+            #expect(Int.random(using: &a) == Int.random(from: .min, to: .max, using: &b))
+        }
+        var c = Seeded(seed: 12), d = Seeded(seed: 12)
+        for _ in 0 ..< 50 {
+            #expect(UInt8.random(using: &c) == UInt8.random(from: .min, to: .max, using: &d))
+            #expect(Int64.random(using: &c) == Int64.random(from: .min, to: .max, using: &d))
+        }
+    }
+
+    /// The whole range, both extremes included, and evenly spread.  A narrow type
+    /// makes that checkable exhaustively.
+    @Test func randomCoversEveryValueOfANarrowType() {
+        var g = Seeded(seed: 13)
+        var counts = [Int](repeating: 0, count: 256)
+        let draws = 256 * 400
+        for _ in 0 ..< draws {
+            counts[Int(UInt8.random(using: &g))] += 1
+        }
+        #expect(!counts.contains(0), "some UInt8 value never came up")
+        let expected = Double(draws) / 256
+        let low = counts.min()!, high = counts.max()!
+        #expect(Double(low) / expected > 0.80, "value seen only \(low) times, expected ~\(Int(expected))")
+        #expect(Double(high) / expected < 1.20, "value seen \(high) times, expected ~\(Int(expected))")
+        // signed, where both extremes are the interesting ones
+        var sawMin = false, sawMax = false, sawNegative = false, sawPositive = false
+        for _ in 0 ..< 20_000 {
+            let v = Int8.random(using: &g)
+            if v == Int8.min { sawMin = true }
+            if v == Int8.max { sawMax = true }
+            if v < 0 { sawNegative = true }
+            if v > 0 { sawPositive = true }
+        }
+        #expect(sawMin && sawMax, "Int8.random() must reach both extremes")
+        #expect(sawNegative && sawPositive, "and both signs")
+    }
+
+    @Test func randomWorksOnEveryBuiltInWidth() {
+        var g = Seeded(seed: 14)
+        // nothing to assert about the value of a full-range draw beyond its type,
+        // so this is a compile-and-run check across the family
+        _ = Int.random(using: &g) ; _ = UInt.random(using: &g)
+        _ = Int8.random(using: &g) ; _ = UInt8.random(using: &g)
+        _ = Int16.random(using: &g) ; _ = UInt16.random(using: &g)
+        _ = Int32.random(using: &g) ; _ = UInt32.random(using: &g)
+        _ = Int64.random(using: &g) ; _ = UInt64.random(using: &g)
+        _ = Int.random() ; _ = UInt8.random()
+        // a full-range unsigned draw must sometimes set the top bit, which a
+        // signed-only path would never do
+        var sawTopBit = false
+        for _ in 0 ..< 200 where !sawTopBit {
+            if UInt64.random(using: &g) >> 63 == 1 { sawTopBit = true }
+        }
+        #expect(sawTopBit, "UInt64.random() should reach above 2^63")
+    }
+
+    /// The power-of-two shortcut is chosen by a helper, and a wrong answer from it
+    /// biases the draw by one value in `limit` — astronomically small for a
+    /// multi-limb bound and so invisible to any distribution test. Checked here
+    /// directly instead.
+    @Test func powerOfTwoDetection() {
+        #expect(_isPowerOfTwo([1]))
+        #expect(_isPowerOfTwo([2]))
+        #expect(_isPowerOfTwo([1 << 63]))
+        #expect(_isPowerOfTwo([0, 1]), "2^64")
+        #expect(_isPowerOfTwo([0, 0, 1]), "2^128")
+        #expect(!_isPowerOfTwo([]), "zero is not a power of two")
+        #expect(!_isPowerOfTwo([0]), "nor is a zero limb")
+        #expect(!_isPowerOfTwo([3]))
+        #expect(!_isPowerOfTwo([UInt.max]))
+        #expect(!_isPowerOfTwo([1, 1]), "2^64 + 1 is one bit per limb across two limbs")
+        #expect(!_isPowerOfTwo([1, 2]))
+        #expect(!_isPowerOfTwo([0, 3]))
+        #expect(!_isPowerOfTwo([1, 0, 1]))
+    }
+
+    /// A power-of-two bound needs no rejection, which is the path `random()` takes
+    /// every time.  It must stay uniform.
+    @Test func powerOfTwoBoundsStayUniform() {
+        var g = Seeded(seed: 15)
+        for k in [1, 2, 3, 8] {
+            let limit = BigUInt(1) << k
+            var counts = [Int](repeating: 0, count: 1 << k)
+            let draws = (1 << k) * 2000
+            for _ in 0 ..< draws {
+                let v = BigUInt.random(lessThan: limit, using: &g)
+                #expect(v < limit)
+                counts[Int(v)] += 1
+            }
+            let expected = Double(draws) / Double(1 << k)
+            for (value, count) in counts.enumerated() {
+                let ratio = Double(count) / expected
+                #expect(0.93 < ratio && ratio < 1.07,
+                        "2^\(k): value \(value) came up \(count) times, expected ~\(Int(expected))")
+            }
+        }
+        #expect(BigUInt.random(lessThan: 1, using: &g) == 0, "only zero is under one")
+    }
+
     /// Every width form can ask for more than the type holds, and then it traps
     /// like any other conversion here. A trap cannot be `#expect`ed, so what is
     /// checked is the boundary either side of it.


### PR DESCRIPTION
Follow-up to #23, which merged while this commit was being pushed — it landed at `805fb29`, so the no-argument form is not in `main`.

## `random()` means the whole range

```swift
Int.random()        // Int.min ... Int.max
UInt8.random()      // 0 ... 255
```

It is defined as `random(from: Self.min, to: Self.max)` and **is** that call, so a seeded generator gives the same value through either spelling — asserted by a test rather than inferred from matching distributions.

It exists **only on the fixed-width types**. `BigInt.random()` and `BigUInt.random()` do not compile, and should not: an unbounded type has no `min` or `max` for a full-range draw to mean anything against. That is also the answer to why the other three forms take an argument. Verified by compiling it and reading the error.

## The default exposed an inefficiency

A whole fixed-width range is a span of 2^bitWidth, and `random(lessThan:)` was rejecting against it: a power-of-two bound has w+1 significant bits, so **half of every draw was thrown away** and `random()` needed two on average for no reason. A power of two is every value of w bits and nothing else, so that case now draws w bits and returns.

Disabling the shortcut leaves every test passing, which is the point — it is an optimisation, not a change of meaning.

## Testing

The full range covered exhaustively for `UInt8` (all 256 values, none more than 20% off its share), both extremes and both signs reached for `Int8`, the seeded equivalence with `random(from:.min,to:.max)`, every built-in width, and uniformity across the new power-of-two path. All distribution assertions use a seeded generator, so they are deterministic.

Four more mutations. Three caught: `random()` over `0...max` instead of `min...max`, the power-of-two path drawing one bit too many, and a wrong answer from the power-of-two test. The fourth — disabling the shortcut — passes by design.

The third needed a test at the helper rather than through the distribution, and that is the interesting one: `_isPowerOfTwo` wrongly accepting one-bit-per-limb across several limbs biases a draw by **one value in `limit`** — around 1 in 2^64 for a multi-limb bound, and invisible to any distribution test that would finish this century. So that helper is now asserted directly on limb arrays.

89 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)