### PR TITLE
Take any signed integer as a power exponent, not just an Int

### DIFF
--- a/BigInt.md
+++ b/BigInt.md
@@ -157,7 +157,7 @@ BigInt(2).power(64)                              // 18446744073709551616
 BigInt(-2).power(3)                              // -8
 BigInt(3).power(0)                               // 1
 BigInt(5).power(-2)                              // 0   -- no integral reciprocal
-BigInt(2).power(UInt8(10))                       // 1024 -- any integer exponent type
+BigInt(2).power(Int8(10))                        // 1024 -- any signed exponent type
 BigInt(2).power(BigInt(10))                      // 1024
 
 BigInt(2).power(64).squareRoot()                 // 4294967296
@@ -238,7 +238,7 @@ A 2048-bit modexp with a 2048-bit exponent runs in tens of milliseconds in a
 release build.
 
 An exponent that wide is only meaningful *with* a modulus, which bounds the answer.
-`power(_:)` accepts one — the exponent is generic over `BinaryInteger` — and rejects
+`power(_:)` accepts one — the exponent is generic over `SignedInteger` — and rejects
 it at runtime past `UInt.max`, because a result needing that many bits has nowhere
 to live:
 
@@ -614,8 +614,10 @@ exception — above `UInt64.max` a prime can come back `nil`.
 
 Two small print items. The modular `power` here has no `Self`-exponent twin like
 the one `BigIntegerType` keeps alongside its generic, because when `Self` is `Int`
-the two would be the same signature and every call site ambiguous. The generic
-covers both anyway. And `squareRoot()` and
+the two would be the same signature and every call site ambiguous. One consequence:
+an unsigned fixed-width exponent has nowhere to resolve — `UInt8(3).power(Int8(4))`
+is fine, `UInt8(3).power(UInt8(4))` is not, since the exponent must be signed and
+there is no concrete twin to fall back on. And `squareRoot()` and
 `greatestCommonDivisor(with:)` already reached the *signed* built-ins through
 `RationalElement`, by this same widen-and-return trick — `Int(10).squareRoot()` is
 not new. Only the unsigned ones gained them, `RationalElement` being a
@@ -632,8 +634,8 @@ public protocol BigIntegerType : BinaryInteger, LosslessStringConvertible, Codab
     func toString(radix: Int, uppercase: Bool) -> String
     init?<S: StringProtocol>(_ text: S, radix: Int)
     func squareRoot() -> Self
-    func power<E: BinaryInteger>(_ exponent: E) -> Self
-    func power<E: BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self
+    func power<E: BinaryInteger & SignedInteger>(_ exponent: E) -> Self
+    func power<E: BinaryInteger & SignedInteger>(_ exponent: E, mod modulus: Self) -> Self
     func power(_ exponent: Self, mod modulus: Self) -> Self
     func greatestCommonDivisor(with other: Self) -> Self
 }
@@ -650,8 +652,15 @@ specializing — which is what `BigInt` and `BigUInt` do for `squareRoot()` and
 square-and-multiply loop, which takes the modulus as an `Optional` and reduces
 after each step when it has one.
 
-The exponent is generic over `BinaryInteger` rather than an `Int`, so any integer
-type can go in that position — `BigInt(2).power(UInt8(10))` and
-`BigInt(2).power(BigInt(10))` both work. The third overload is what the generic
-already covers, kept because overload resolution prefers a concrete signature and
-because a `Self` exponent is the shape the cryptographic case uses.
+The exponent is generic over `SignedInteger` rather than an `Int`, so any signed
+integer type can go in that position — `BigInt(2).power(Int8(10))` and
+`BigInt(2).power(BigInt(10))` both work. Signed and not merely `BinaryInteger`
+because a negative exponent is half of what `power` means: 0 for `power(_:)`, the
+modular inverse for `power(_:mod:)`. An unsigned exponent type cannot express that
+argument at all, so it is refused at compile time rather than left as a documented
+behaviour the caller can never reach.
+
+The third overload is therefore not redundant. Where `Self` is signed the generic
+covers it and the compiler simply prefers the concrete signature; where `Self` is
+**unsigned** it is the only route, and it is what keeps
+`BigUInt(3).power(BigUInt(1) << 100, mod: m)` — the cryptographic shape — compiling.

--- a/BigInt.md
+++ b/BigInt.md
@@ -634,8 +634,8 @@ public protocol BigIntegerType : BinaryInteger, LosslessStringConvertible, Codab
     func toString(radix: Int, uppercase: Bool) -> String
     init?<S: StringProtocol>(_ text: S, radix: Int)
     func squareRoot() -> Self
-    func power<E: BinaryInteger & SignedInteger>(_ exponent: E) -> Self
-    func power<E: BinaryInteger & SignedInteger>(_ exponent: E, mod modulus: Self) -> Self
+    func power<E: SignedInteger>(_ exponent: E) -> Self
+    func power<E: SignedInteger>(_ exponent: E, mod modulus: Self) -> Self
     func power(_ exponent: Self, mod modulus: Self) -> Self
     func greatestCommonDivisor(with other: Self) -> Self
 }

--- a/BigInt.md
+++ b/BigInt.md
@@ -157,6 +157,8 @@ BigInt(2).power(64)                              // 18446744073709551616
 BigInt(-2).power(3)                              // -8
 BigInt(3).power(0)                               // 1
 BigInt(5).power(-2)                              // 0   -- no integral reciprocal
+BigInt(2).power(UInt8(10))                       // 1024 -- any integer exponent type
+BigInt(2).power(BigInt(10))                      // 1024
 
 BigInt(2).power(64).squareRoot()                 // 4294967296
 BigInt(10).squareRoot()                          // 3   -- floor(sqrt(10))
@@ -233,9 +235,18 @@ BigUInt(3).power(BigUInt(1) << 100, mod: 1000000007)   // 870513414
 ```
 
 A 2048-bit modexp with a 2048-bit exponent runs in tens of milliseconds in a
-release build. There is deliberately no `power(_: Self)` without a modulus to match: an exponent
-past `Int` has no representable answer there, since the result would want more
-bits than the machine has.
+release build.
+
+An exponent that wide is only meaningful *with* a modulus, which bounds the answer.
+`power(_:)` accepts one — the exponent is generic over `BinaryInteger` — and rejects
+it at runtime past `UInt.max`, because a result needing that many bits has nowhere
+to live:
+
+```swift
+BigInt(2).power(BigInt(10))         // 1024 -- a wide exponent type is fine
+BigInt(2).power(BigInt(1) << 70)    // traps: more bits than there are addresses
+BigInt(2).power(BigInt(1) << 70, mod: 1000000007)   // 100126750 -- bounded, so fine
+```
 
 ## Conversions
 
@@ -601,10 +612,10 @@ UInt8(200).power(200, mod: 251)         // 1, though 200 * 200 overflows a UInt8
 can hold falls outside the exhaustively verified range. A 128-bit type is the
 exception — above `UInt64.max` a prime can come back `nil`.
 
-Two small print items. The modular `power` takes its exponent generically
-(`power<E: BinaryInteger>(_:mod:)`) rather than as the `Int`/`Self` pair
-`BigIntegerType` uses, because when `Self` is `Int` those two are the same
-signature and every call site is ambiguous. And `squareRoot()` and
+Two small print items. The modular `power` here has no `Self`-exponent twin like
+the one `BigIntegerType` keeps alongside its generic, because when `Self` is `Int`
+the two would be the same signature and every call site ambiguous. The generic
+covers both anyway. And `squareRoot()` and
 `greatestCommonDivisor(with:)` already reached the *signed* built-ins through
 `RationalElement`, by this same widen-and-return trick — `Int(10).squareRoot()` is
 not new. Only the unsigned ones gained them, `RationalElement` being a
@@ -621,8 +632,8 @@ public protocol BigIntegerType : BinaryInteger, LosslessStringConvertible, Codab
     func toString(radix: Int, uppercase: Bool) -> String
     init?<S: StringProtocol>(_ text: S, radix: Int)
     func squareRoot() -> Self
-    func power(_ exponent: Int) -> Self
-    func power(_ exponent: Int, mod modulus: Self) -> Self
+    func power<E: BinaryInteger>(_ exponent: E) -> Self
+    func power<E: BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self
     func power(_ exponent: Self, mod modulus: Self) -> Self
     func greatestCommonDivisor(with other: Self) -> Self
 }
@@ -638,3 +649,9 @@ specializing — which is what `BigInt` and `BigUInt` do for `squareRoot()` and
 `greatestCommonDivisor(with:)`. The three `power`s share a single
 square-and-multiply loop, which takes the modulus as an `Optional` and reduces
 after each step when it has one.
+
+The exponent is generic over `BinaryInteger` rather than an `Int`, so any integer
+type can go in that position — `BigInt(2).power(UInt8(10))` and
+`BigInt(2).power(BigInt(10))` both work. The third overload is what the generic
+already covers, kept because overload resolution prefers a concrete signature and
+because a `Self` exponent is the shape the cryptographic case uses.

--- a/CAVEAT.md
+++ b/CAVEAT.md
@@ -202,7 +202,7 @@ compile unchanged.
   forms
 * `quotientAndRemainder(dividingBy:)`, `isMultiple(of:)`, `negate()`, `signum()`,
   `magnitude`, `isZero`, `isSigned`
-* `power(_:)` — ours takes any `BinaryInteger` exponent where attaswift takes an
+* `power(_:)` — ours takes any `SignedInteger` exponent where attaswift takes an
   `Int`, so every attaswift call still compiles — `squareRoot()`,
   `greatestCommonDivisor(with:)`
 * `words`, `Words`, `Magnitude`, `bitWidth`, `trailingZeroBitCount`

--- a/CAVEAT.md
+++ b/CAVEAT.md
@@ -202,7 +202,8 @@ compile unchanged.
   forms
 * `quotientAndRemainder(dividingBy:)`, `isMultiple(of:)`, `negate()`, `signum()`,
   `magnitude`, `isZero`, `isSigned`
-* `power(_:)` with an `Int` exponent, `squareRoot()`,
+* `power(_:)` — ours takes any `BinaryInteger` exponent where attaswift takes an
+  `Int`, so every attaswift call still compiles — `squareRoot()`,
   `greatestCommonDivisor(with:)`
 * `words`, `Words`, `Magnitude`, `bitWidth`, `trailingZeroBitCount`
 * `Codable` (the protocol; see the format caveat above), `Hashable`, `Comparable`

--- a/Sources/BigNum/BigIntType.swift
+++ b/Sources/BigNum/BigIntType.swift
@@ -28,11 +28,14 @@ public protocol BigIntegerType : BinaryInteger, LosslessStringConvertible, Codab
     /// ⌊√self⌋.  Traps on a negative `self`.
     func squareRoot() -> Self
     /// `self` raised to `exponent`.
-    func power(_ exponent: Int) -> Self
+    func power<E:BinaryInteger>(_ exponent: E) -> Self
     /// `self` raised to `exponent`, reduced modulo `modulus` -- Python's
     /// three-argument `pow()`.
-    func power(_ exponent: Int, mod modulus: Self) -> Self
-    /// The same, for an exponent too wide to be an `Int`.
+    func power<E:BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self
+    /// The same for a `Self` exponent, which the generic above already covers --
+    /// `Self` is a `BinaryInteger`.  Kept because it is the concrete overload the
+    /// compiler prefers, and because it is the shape the cryptographic case
+    /// actually uses, where the exponent is as wide as the modulus.
     func power(_ exponent: Self, mod modulus: Self) -> Self
     /// The greatest common divisor of `self` and `other`, always non-negative.
     func greatestCommonDivisor(with other: Self) -> Self
@@ -188,7 +191,13 @@ extension BigIntegerType {
 
     /// A negative `exponent` has no integral answer, so it yields 0 except for
     /// the two values that are their own reciprocal.
-    public func power(_ exponent: Int) -> Self {
+    ///
+    /// The exponent is generic so that any integer type can be written here, but
+    /// it still has to fit a `UInt`: a bigger one names a result with more bits
+    /// than the machine can address, whatever type it arrived in.  Reach for
+    /// `power(_:mod:)`, which is bounded by its modulus and does not care how wide
+    /// the exponent is.
+    public func power<E:BinaryInteger>(_ exponent: E) -> Self {
         if exponent == 0 { return 1 }
         if exponent == 1 { return self }
         if exponent < 0 {
@@ -199,7 +208,14 @@ extension BigIntegerType {
             if Self.isSigned && self == 0 - 1 { return exponent % 2 == 0 ? 1 : self }
             return 0
         }
-        return self._squareAndMultiply(UInt(exponent), mod: nil)
+        guard let e = UInt(exactly: exponent) else {
+            // Said here rather than left to the trap inside `UInt.init`, which
+            // would blame a numeric conversion for what is really a request that
+            // has no answer.
+            preconditionFailure("power(\(exponent)) needs more bits than there are"
+                              + " addresses; use power(_:mod:) for an exponent this wide")
+        }
+        return self._squareAndMultiply(e, mod: nil)
     }
 
     /// `self`⁻¹ mod `modulus` by the extended Euclidean algorithm, or nil when
@@ -236,16 +252,20 @@ extension BigIntegerType {
     /// Only the modulus bounds the intermediates, so this stays cheap where
     /// `power(_:)` could not run at all: `e` squarings of a value no wider than
     /// `modulus`, rather than a result with `e * self.bitWidth` bits.
-    public func power(_ exponent: Int, mod modulus: Self) -> Self {
+    public func power<E:BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self {
         return self._power(exponent, mod: modulus)
     }
 
-    /// `power(_:mod:)` for an exponent too large to be an `Int`, which is the
-    /// usual case in cryptography -- an RSA exponent is as wide as its modulus.
+    /// `power(_:mod:)` with a `Self` exponent, which is the usual case in
+    /// cryptography -- an RSA exponent is as wide as its modulus.
     ///
-    /// There is deliberately no `power(_: Self)` to match: without a modulus an
-    /// exponent past `Int` has no representable answer anyway, since the result
-    /// would need more bits than the machine has.
+    /// The generic overload above covers this, `Self` being a `BinaryInteger`, so
+    /// this one is a concrete specialization rather than extra reach.  Overload
+    /// resolution prefers it, which is why it stays.
+    ///
+    /// Note that a modulus is what makes a wide exponent meaningful: `power(_:)`
+    /// accepts a `Self` exponent too, and rejects one past `UInt.max` at runtime,
+    /// because a result that big has nowhere to live.
     public func power(_ exponent: Self, mod modulus: Self) -> Self {
         return self._power(exponent, mod: modulus)
     }

--- a/Sources/BigNum/BigIntType.swift
+++ b/Sources/BigNum/BigIntType.swift
@@ -28,10 +28,10 @@ public protocol BigIntegerType : BinaryInteger, LosslessStringConvertible, Codab
     /// ⌊√self⌋.  Traps on a negative `self`.
     func squareRoot() -> Self
     /// `self` raised to `exponent`.
-    func power<E:BinaryInteger & SignedInteger>(_ exponent: E) -> Self
+    func power<E:SignedInteger>(_ exponent: E) -> Self
     /// `self` raised to `exponent`, reduced modulo `modulus` -- Python's
     /// three-argument `pow()`.
-    func power<E:BinaryInteger & SignedInteger>(_ exponent: E, mod modulus: Self) -> Self
+    func power<E:SignedInteger>(_ exponent: E, mod modulus: Self) -> Self
     /// The same for a `Self` exponent.  Where `Self` is signed the generic above
     /// covers it and the compiler prefers this concrete signature; where `Self` is
     /// *unsigned* this is the only route, and it is what lets a `BigUInt` exponent
@@ -202,7 +202,7 @@ extension BigIntegerType {
     /// names a result with more bits than the machine can address, whatever type it
     /// arrived in.  Reach for `power(_:mod:)`, which is bounded by its modulus and
     /// does not care how wide the exponent is.
-    public func power<E:BinaryInteger & SignedInteger>(_ exponent: E) -> Self {
+    public func power<E:SignedInteger>(_ exponent: E) -> Self {
         if exponent == 0 { return 1 }
         if exponent == 1 { return self }
         if exponent < 0 {
@@ -257,7 +257,7 @@ extension BigIntegerType {
     /// Only the modulus bounds the intermediates, so this stays cheap where
     /// `power(_:)` could not run at all: `e` squarings of a value no wider than
     /// `modulus`, rather than a result with `e * self.bitWidth` bits.
-    public func power<E:BinaryInteger & SignedInteger>(_ exponent: E, mod modulus: Self) -> Self {
+    public func power<E:SignedInteger>(_ exponent: E, mod modulus: Self) -> Self {
         return self._power(exponent, mod: modulus)
     }
 

--- a/Sources/BigNum/BigIntType.swift
+++ b/Sources/BigNum/BigIntType.swift
@@ -28,14 +28,14 @@ public protocol BigIntegerType : BinaryInteger, LosslessStringConvertible, Codab
     /// ⌊√self⌋.  Traps on a negative `self`.
     func squareRoot() -> Self
     /// `self` raised to `exponent`.
-    func power<E:BinaryInteger>(_ exponent: E) -> Self
+    func power<E:BinaryInteger & SignedInteger>(_ exponent: E) -> Self
     /// `self` raised to `exponent`, reduced modulo `modulus` -- Python's
     /// three-argument `pow()`.
-    func power<E:BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self
-    /// The same for a `Self` exponent, which the generic above already covers --
-    /// `Self` is a `BinaryInteger`.  Kept because it is the concrete overload the
-    /// compiler prefers, and because it is the shape the cryptographic case
-    /// actually uses, where the exponent is as wide as the modulus.
+    func power<E:BinaryInteger & SignedInteger>(_ exponent: E, mod modulus: Self) -> Self
+    /// The same for a `Self` exponent.  Where `Self` is signed the generic above
+    /// covers it and the compiler prefers this concrete signature; where `Self` is
+    /// *unsigned* this is the only route, and it is what lets a `BigUInt` exponent
+    /// -- the cryptographic shape, as wide as the modulus -- still be written.
     func power(_ exponent: Self, mod modulus: Self) -> Self
     /// The greatest common divisor of `self` and `other`, always non-negative.
     func greatestCommonDivisor(with other: Self) -> Self
@@ -192,12 +192,17 @@ extension BigIntegerType {
     /// A negative `exponent` has no integral answer, so it yields 0 except for
     /// the two values that are their own reciprocal.
     ///
-    /// The exponent is generic so that any integer type can be written here, but
-    /// it still has to fit a `UInt`: a bigger one names a result with more bits
-    /// than the machine can address, whatever type it arrived in.  Reach for
-    /// `power(_:mod:)`, which is bounded by its modulus and does not care how wide
-    /// the exponent is.
-    public func power<E:BinaryInteger>(_ exponent: E) -> Self {
+    /// The exponent is generic over the *signed* integers.  Signed rather than
+    /// `BinaryInteger`, because that reciprocal is half of what this method means:
+    /// an unsigned exponent type could not express the case, so the branch below
+    /// would be unreachable and the caller would have written something whose
+    /// documented behaviour cannot occur.  Better to say so at compile time.
+    ///
+    /// Any width is accepted, but the value still has to fit a `UInt`: a bigger one
+    /// names a result with more bits than the machine can address, whatever type it
+    /// arrived in.  Reach for `power(_:mod:)`, which is bounded by its modulus and
+    /// does not care how wide the exponent is.
+    public func power<E:BinaryInteger & SignedInteger>(_ exponent: E) -> Self {
         if exponent == 0 { return 1 }
         if exponent == 1 { return self }
         if exponent < 0 {
@@ -252,20 +257,22 @@ extension BigIntegerType {
     /// Only the modulus bounds the intermediates, so this stays cheap where
     /// `power(_:)` could not run at all: `e` squarings of a value no wider than
     /// `modulus`, rather than a result with `e * self.bitWidth` bits.
-    public func power<E:BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self {
+    public func power<E:BinaryInteger & SignedInteger>(_ exponent: E, mod modulus: Self) -> Self {
         return self._power(exponent, mod: modulus)
     }
 
     /// `power(_:mod:)` with a `Self` exponent, which is the usual case in
     /// cryptography -- an RSA exponent is as wide as its modulus.
     ///
-    /// The generic overload above covers this, `Self` being a `BinaryInteger`, so
-    /// this one is a concrete specialization rather than extra reach.  Overload
-    /// resolution prefers it, which is why it stays.
+    /// This one is load-bearing, not a convenience.  For a signed `Self` the
+    /// generic above also matches and the compiler merely prefers the concrete
+    /// signature; for an **unsigned** `Self` it is the only route, `Self` not being
+    /// a `SignedInteger`.  It is what keeps
+    /// `BigUInt(3).power(BigUInt(1) << 100, mod: m)` compiling.
     ///
     /// Note that a modulus is what makes a wide exponent meaningful: `power(_:)`
-    /// accepts a `Self` exponent too, and rejects one past `UInt.max` at runtime,
-    /// because a result that big has nowhere to live.
+    /// takes one too, and rejects it past `UInt.max` at runtime, because a result
+    /// that big has nowhere to live.
     public func power(_ exponent: Self, mod modulus: Self) -> Self {
         return self._power(exponent, mod: modulus)
     }

--- a/Sources/BigNum/FixedWidthInteger.swift
+++ b/Sources/BigNum/FixedWidthInteger.swift
@@ -42,7 +42,7 @@ extension FixedWidthInteger {
     /// Traps unless the result is representable -- `Int(2).power(1024)` is not a
     /// number an `Int` has.  Use `BigInt(self).power(exponent)` for one that can
     /// hold it.
-    public func power<E:BinaryInteger & SignedInteger>(_ exponent: E) -> Self {
+    public func power<E:SignedInteger>(_ exponent: E) -> Self {
         return Self(BigInt(self).power(exponent))
     }
 
@@ -63,7 +63,7 @@ extension FixedWidthInteger {
     /// `BigIntegerType` keeps: when `Self` is `Int` the two would be the same
     /// signature, and every call ambiguous.  The generic covers both, and takes a
     /// `BigInt` exponent as well.
-    public func power<E:BinaryInteger & SignedInteger>(_ exponent: E, mod modulus: Self) -> Self {
+    public func power<E:SignedInteger>(_ exponent: E, mod modulus: Self) -> Self {
         return Self(BigInt(self).power(BigInt(exponent), mod: BigInt(modulus)))
     }
 }

--- a/Sources/BigNum/FixedWidthInteger.swift
+++ b/Sources/BigNum/FixedWidthInteger.swift
@@ -42,7 +42,7 @@ extension FixedWidthInteger {
     /// Traps unless the result is representable -- `Int(2).power(1024)` is not a
     /// number an `Int` has.  Use `BigInt(self).power(exponent)` for one that can
     /// hold it.
-    public func power<E:BinaryInteger>(_ exponent: E) -> Self {
+    public func power<E:BinaryInteger & SignedInteger>(_ exponent: E) -> Self {
         return Self(BigInt(self).power(exponent))
     }
 
@@ -63,7 +63,7 @@ extension FixedWidthInteger {
     /// `BigIntegerType` keeps: when `Self` is `Int` the two would be the same
     /// signature, and every call ambiguous.  The generic covers both, and takes a
     /// `BigInt` exponent as well.
-    public func power<E:BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self {
+    public func power<E:BinaryInteger & SignedInteger>(_ exponent: E, mod modulus: Self) -> Self {
         return Self(BigInt(self).power(BigInt(exponent), mod: BigInt(modulus)))
     }
 }

--- a/Sources/BigNum/FixedWidthInteger.swift
+++ b/Sources/BigNum/FixedWidthInteger.swift
@@ -42,7 +42,7 @@ extension FixedWidthInteger {
     /// Traps unless the result is representable -- `Int(2).power(1024)` is not a
     /// number an `Int` has.  Use `BigInt(self).power(exponent)` for one that can
     /// hold it.
-    public func power(_ exponent: Int) -> Self {
+    public func power<E:BinaryInteger>(_ exponent: E) -> Self {
         return Self(BigInt(self).power(exponent))
     }
 
@@ -59,9 +59,9 @@ extension FixedWidthInteger {
     ///     Int(2).power(1024, mod: 1_000_000_007)      // 812734592
     ///     Int(2).power(1024) % 1_000_000_007          // traps
     ///
-    /// One generic overload rather than the `Int` and `Self` pair
-    /// `BigIntegerType` has: when `Self` is `Int` those two are the same
-    /// signature, and every call is ambiguous.  Generic covers both and takes a
+    /// One generic overload, with no `Self`-exponent twin like the one
+    /// `BigIntegerType` keeps: when `Self` is `Int` the two would be the same
+    /// signature, and every call ambiguous.  The generic covers both, and takes a
     /// `BigInt` exponent as well.
     public func power<E:BinaryInteger>(_ exponent: E, mod modulus: Self) -> Self {
         return Self(BigInt(self).power(BigInt(exponent), mod: BigInt(modulus)))

--- a/Tests/BigNumTests/FixedWidthIntegerTests.swift
+++ b/Tests/BigNumTests/FixedWidthIntegerTests.swift
@@ -56,43 +56,52 @@ import Testing
         #expect(Int(1).power(-9) == 1 && Int(-1).power(-9) == -1)
     }
 
-    /// The exponent is generic over `BinaryInteger` rather than an `Int`, so any
-    /// integer type can be written in that position.  Only the first line of each
-    /// group below compiled before it was.
+    /// The exponent is generic over `SignedInteger` rather than an `Int`, so any
+    /// *signed* integer type can be written in that position.  Only the first line
+    /// of each group below compiled when it was an `Int`.
+    ///
+    /// Signed and not merely `BinaryInteger`, because a negative exponent is part
+    /// of what `power` means -- the reciprocal, which is 0 for `power(_:)` and the
+    /// modular inverse for `power(_:mod:)`.  An unsigned exponent type cannot
+    /// express the argument the documented behaviour is about, so it is rejected at
+    /// compile time rather than silently made unreachable.
     ///
     /// This is a compile-time claim as much as a runtime one: every line here is a
     /// distinct overload resolution, and the test earns its keep by failing to
     /// build if one of them stops resolving.
-    @Test func anyIntegerTypeCanBeAnExponent() {
+    @Test func anySignedIntegerTypeCanBeAnExponent() {
         // a fixed-width receiver
         #expect(Int(2).power(10) == 1024)
-        #expect(Int(2).power(UInt8(10)) == 1024)
+        #expect(Int(2).power(Int8(10)) == 1024)
+        #expect(Int(2).power(Int32(10)) == 1024)
         #expect(Int(2).power(BigInt(10)) == 1024)
-        #expect(Int(2).power(BigUInt(10)) == 1024)
-        #expect(UInt8(3).power(UInt8(4)) == 81)
+        // the receiver may still be unsigned; it is the exponent that may not be
+        #expect(UInt8(3).power(Int8(4)) == 81)
+        #expect(UInt(2).power(BigInt(63)) == 9223372036854775808)
         // a big receiver
         #expect(BigInt(2).power(10) == 1024)
-        #expect(BigInt(2).power(UInt8(10)) == 1024)
+        #expect(BigInt(2).power(Int8(10)) == 1024)
         #expect(BigInt(2).power(BigInt(10)) == 1024)
-        #expect(BigInt(2).power(BigUInt(10)) == 1024)
-        #expect(BigUInt(2).power(UInt(10)) == 1024)
+        #expect(BigUInt(2).power(Int64(10)) == 1024)
         // the sign rules do not change with the exponent's type
         #expect(BigInt(-2).power(Int8(3)) == -8)
         #expect(BigInt(5).power(Int8(-2)) == 0)
         #expect(BigInt(-1).power(Int16(-3)) == -1)
         #expect(Int(-2).power(Int8(3)) == -8)
         // and neither do the modular ones
-        #expect(BigInt(3).power(UInt8(5), mod: BigInt(7)) == 5)
+        #expect(BigInt(3).power(Int8(5), mod: BigInt(7)) == 5)
         #expect(BigInt(3).power(BigInt(5), mod: BigInt(7)) == 5)
-        #expect(BigInt(3).power(BigUInt(5), mod: BigInt(7)) == 5)
         #expect(BigInt(2).power(Int8(-1), mod: 5) == 3)
-        #expect(Int(2).power(UInt16(1024), mod: 1_000_000_007) == 812734592)
+        #expect(Int(2).power(Int16(1024), mod: 1_000_000_007) == 812734592)
+        // The one place an unsigned exponent still resolves: `power(_ exponent:
+        // Self, mod:)` is concrete, so an unsigned receiver reaches it with its own
+        // type.  That is the cryptographic case, and it keeps working.
+        #expect(BigUInt(3).power(BigUInt(1) << 100, mod: 1000000007) == 870513414)
         // An exponent past `UInt` is meaningful only with a modulus to bound the
         // answer, and `power(_:)` rejects one.  A trap cannot be `#expect`ed, so
         // what is checked here is the boundary it has to *accept* -- if the guard
         // were off by one this would trap rather than fail.
-        #expect(BigUInt(3).power(BigUInt(1) << 100, mod: 1000000007) == 870513414)
-        #expect(BigInt(1).power(UInt.max) == 1)
+        #expect(BigInt(1).power(BigInt(UInt.max)) == 1)
     }
 
     /// The modular form is the one that cannot overflow, since the answer is
@@ -130,10 +139,13 @@ import Testing
         #expect(Int(2).power(3, mod: -5) == -2, "a negative modulus")
         #expect(Int(2).power(-1, mod: 5) == 3, "a negative exponent is the inverse")
         #expect(Int(5).power(3, mod: 1) == 0)
-        // the exponent is generic, so all of these have to compile and agree
+        // the exponent is generic over the signed integers, so all of these have to
+        // compile and agree.  `UInt8(20)` was here and no longer compiles: the
+        // exponent is `SignedInteger` now, since a negative one is half of what
+        // `power(_:mod:)` is documented to do.
         #expect(Int(3).power(20, mod: 1_000_003) == 773943)
         #expect(Int(3).power(Int(20), mod: 1_000_003) == 773943)
-        #expect(Int(3).power(UInt8(20), mod: 1_000_003) == 773943)
+        #expect(Int(3).power(Int8(20), mod: 1_000_003) == 773943)
         #expect(Int(3).power(BigInt(20), mod: 1_000_003) == 773943)
     }
 

--- a/Tests/BigNumTests/FixedWidthIntegerTests.swift
+++ b/Tests/BigNumTests/FixedWidthIntegerTests.swift
@@ -56,6 +56,45 @@ import Testing
         #expect(Int(1).power(-9) == 1 && Int(-1).power(-9) == -1)
     }
 
+    /// The exponent is generic over `BinaryInteger` rather than an `Int`, so any
+    /// integer type can be written in that position.  Only the first line of each
+    /// group below compiled before it was.
+    ///
+    /// This is a compile-time claim as much as a runtime one: every line here is a
+    /// distinct overload resolution, and the test earns its keep by failing to
+    /// build if one of them stops resolving.
+    @Test func anyIntegerTypeCanBeAnExponent() {
+        // a fixed-width receiver
+        #expect(Int(2).power(10) == 1024)
+        #expect(Int(2).power(UInt8(10)) == 1024)
+        #expect(Int(2).power(BigInt(10)) == 1024)
+        #expect(Int(2).power(BigUInt(10)) == 1024)
+        #expect(UInt8(3).power(UInt8(4)) == 81)
+        // a big receiver
+        #expect(BigInt(2).power(10) == 1024)
+        #expect(BigInt(2).power(UInt8(10)) == 1024)
+        #expect(BigInt(2).power(BigInt(10)) == 1024)
+        #expect(BigInt(2).power(BigUInt(10)) == 1024)
+        #expect(BigUInt(2).power(UInt(10)) == 1024)
+        // the sign rules do not change with the exponent's type
+        #expect(BigInt(-2).power(Int8(3)) == -8)
+        #expect(BigInt(5).power(Int8(-2)) == 0)
+        #expect(BigInt(-1).power(Int16(-3)) == -1)
+        #expect(Int(-2).power(Int8(3)) == -8)
+        // and neither do the modular ones
+        #expect(BigInt(3).power(UInt8(5), mod: BigInt(7)) == 5)
+        #expect(BigInt(3).power(BigInt(5), mod: BigInt(7)) == 5)
+        #expect(BigInt(3).power(BigUInt(5), mod: BigInt(7)) == 5)
+        #expect(BigInt(2).power(Int8(-1), mod: 5) == 3)
+        #expect(Int(2).power(UInt16(1024), mod: 1_000_000_007) == 812734592)
+        // An exponent past `UInt` is meaningful only with a modulus to bound the
+        // answer, and `power(_:)` rejects one.  A trap cannot be `#expect`ed, so
+        // what is checked here is the boundary it has to *accept* -- if the guard
+        // were off by one this would trap rather than fail.
+        #expect(BigUInt(3).power(BigUInt(1) << 100, mod: 1000000007) == 870513414)
+        #expect(BigInt(1).power(UInt.max) == 1)
+    }
+
     /// The modular form is the one that cannot overflow, since the answer is
     /// bounded by a modulus that is a `Self` already.  It is therefore also the
     /// one worth checking at full width.


### PR DESCRIPTION
`power(_:)` and `power(_:mod:)` on `BigIntegerType`, and both on the built-in fixed-width types, now read:

```swift
func power<E: SignedInteger>(_ exponent: E) -> Self
func power<E: SignedInteger>(_ exponent: E, mod modulus: Self) -> Self
```

The square-and-multiply loop they share was already generic over its exponent, so the plumbing existed:

```swift
BigInt(2).power(Int8(10))      // 1024
BigInt(2).power(BigInt(10))    // 1024
Int(2).power(BigInt(10))       // 1024
UInt8(3).power(Int8(4))        // 81 -- the receiver may be unsigned
```

**Signed**, not merely `BinaryInteger`, because a negative exponent is half of what `power` means — 0 for `power(_:)`, the modular inverse for `power(_:mod:)`. An unsigned exponent type cannot express the argument that documented behaviour is about, so the reciprocal branch would be unreachable for it. Said at compile time instead.

## Three consequences worth naming

**It narrows as well as widens.** One pre-existing assertion went with it — `Int(3).power(UInt8(20), mod: 1_000_003)`, sitting under a comment reading *"the exponent is generic, so all of these have to compile and agree"*. It is now `Int8(20)`, and the comment records what changed.

**`power(_ exponent: Self, mod:)` becomes load-bearing.** For a signed `Self` the generic still matches and the compiler merely prefers the concrete signature; for an **unsigned** `Self` it is now the only route, `BigUInt` not being a `SignedInteger`. It is what keeps `BigUInt(3).power(BigUInt(1) << 100, mod: m)` — the cryptographic shape — compiling. Its doc comment claimed the opposite mid-branch and now says this.

**The fixed-width modular form has no such twin**, deliberately: when `Self` is `Int` the two signatures would collide. So an unsigned fixed-width exponent has nowhere to resolve — `UInt8(3).power(Int8(4))` compiles, `UInt8(3).power(UInt8(4))` does not. Only the exponent is constrained, never the receiver. BigInt.md says so.

**An exponent past `UInt.max` is now writable**, and names a result with more bits than the machine can address. It is rejected with that as the message rather than trapping inside `UInt.init`, which would blame a numeric conversion for a request that has no answer:

```
Fatal error: power(1180591620717411303424) needs more bits than there are
addresses; use power(_:mod:) for an exponent this wide
```

## Compatibility

Unaffected. attaswift's `power(_:)` takes an `Int` and its `power(_:modulus:)` takes the receiver's own type — exactly the pair still accepted. Verified against its source (`Sources/Exponentiation.swift` in the checkout), not from memory.

## Testing

`anySignedIntegerTypeCanBeAnExponent` is a compile-time test as much as a runtime one: every line is a distinct overload resolution, so it fails to *build* if one stops resolving. It covers both receivers, unsigned receivers with signed exponents, the sign rules, the modular forms, the one place an unsigned exponent still resolves, and the boundary `power(_:)` must accept — now written `BigInt(UInt.max)`, since `UInt.max` itself no longer compiles there.

98 tests pass from a clean `.build`.

Docs updated: BigInt.md's protocol listing, number-theory examples, modexp section and small print, plus CAVEAT.md's compatibility list. Every new documented value was executed, not typed — `BigInt(2).power(BigInt(1) << 70, mod: 1000000007)` is 100126750, agreeing with Python's `pow`.

## On the spelling

The constraint went in as `<E: BinaryInteger & SignedInteger>` and is now just `<E: SignedInteger>` — `SignedInteger` already refines `BinaryInteger`, and the mangled symbol is identical under both (`power<A where A1: Swift.SignedInteger>(A1) -> A`), which is why the third commit needed no relink where the second did.

`_squareAndMultiply` keeps `<E: BinaryInteger>`: it takes the already-sign-stripped `UInt`, where a signed constraint would be wrong.

## A build-system wrinkle, not a code one

Changing `BinaryInteger` to a signed constraint left `ExponentiationTests.swift.o` stale, still referencing the old symbol, and the test link failed. `swift build --target BigNumOperatorsTests` reported "complete" in 0.17s without recompiling — SwiftPM does not treat a cross-module generic-constraint change as invalidating. Deleting the object fixed it, and clean builds are unaffected, so CI should be fine. Worth knowing if you pull this onto a warm `.build`.

## Not included

The `**` operator still takes an `Int` exponent, so `BigInt(2) ** BigInt(10)` does not compile while `.power(BigInt(10))` does. Generalizing it builds and passes the existing operator tests — including the all-literal `2 ** 10`, `BigRat(2) ** 10` and `Double` cases most at risk from a wider overload set — but it is a separate module, so it is left out. One line if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)