### PR TITLE
Compare BigFloat and BigRat by value, and add a Complex<BigRat>/Complex<BigFloat> example

### DIFF
--- a/BigFloat.md
+++ b/BigFloat.md
@@ -186,6 +186,29 @@ BigFloat.nan === BigFloat.nan    // true
 
 `isIdentical(to:)` is the spelled-out form of `===`.
 
+The two are further apart than they look, because **the same number can be stored
+more than one way**. `init(scale:mantissa:)` normalizes — it moves the mantissa's
+trailing zeros into the scale — but `truncate(width:)` rounds the mantissa in place
+without doing that, and `scale` and `mantissa` are settable anyway:
+
+```swift
+let a = BigFloat.sqrt(BigFloat(2))          // mantissa 129 bits
+let b = BigFloat.SQRT2(precision: 128)      // mantissa 641 bits, low 512 zeroed
+a == b                           // true   -- one number
+a === b                          // false  -- two shapes
+a.mantissa.bitWidth              // 129
+b.mantissa.bitWidth              // 641
+
+BigFloat.pow(BigFloat(4), BigFloat(0.5)) == 2    // true, stored as 2⁷⁶³ × 2⁻⁷⁶²
+```
+
+So `==` compares values and `===` compares storage, and only the first of those is
+a number question. Up to 5.x `==` compared storage too, which made `a == b` false —
+and, worse, made `a < b`, `a == b` and `a > b` *all* false, where `Comparable`
+requires exactly one to hold. `<` was never affected: it compares by subtraction.
+
+`hashValue` follows `==`, so the two spellings of √2 above land in one `Set` slot.
+
 ## Specials
 
 ```swift

--- a/BigRat.md
+++ b/BigRat.md
@@ -136,6 +136,32 @@ why `toString(.fraction)` is the format that can still show it — `(+0/-1)`.
 > is that `atan2(-0, x)` returns `+0` instead of `-0` for finite positive `x`;
 > `ElementaryFunctionsTests` records it as a known issue.
 
+## Equality compares numbers, not fractions
+
+One number has many spellings as a fraction, and `BigRat` does not always hand you
+the reduced one. `init(_:_:)` reduces — `BigRat(2,4).den` is 2 — but `init(num:den:)`
+is the primitive underneath it and stores what it is given, `num` and `den` are
+settable, and `BigRat(someBigFloat)` writes `mantissa / 2^-scale` without reducing:
+
+```swift
+let a = BigRat(BigFloat.sqrt(BigFloat(2)))        // den 129 bits
+let b = BigRat(BigFloat.SQRT2(precision: 128))    // den 641 bits
+a == b                                            // true  -- one number
+a.isIdentical(to: b)                              // false -- two fractions
+BigRat(num: BigInt(2), den: BigInt(4)) == BigRat(1, 2)      // true
+BigRat(num: BigInt(-1), den: BigInt(-2)) == BigRat(1, 2)    // true
+```
+
+`==` cross-multiplies; `isIdentical(to:)` compares `num` and `den`. `hashValue`
+follows `==`, so the two spellings of √2 above share one `Set` slot. There is no
+`===` operator here — that one is `BigFloat`'s.
+
+Up to 5.x `==` compared the fraction, which called that pair unequal and left
+`a < b`, `a == b` and `a > b` **all** false, where `Comparable` requires exactly one
+to hold. `<` was never affected: it already cross-multiplied. The same fix landed on
+[`BigFloat`](BigFloat.md#equality-and-identity), whose `==` compared `scale` and
+`mantissa`.
+
 ## Mixed numbers, rounding and conversions
 
 ```swift

--- a/Sources/BigNum/BigFloat.swift
+++ b/Sources/BigNum/BigFloat.swift
@@ -255,13 +255,57 @@ extension BigFloat {
     public static func ===(_ lhs:BigFloat, _ rhs:BigFloat)->Bool {
         return lhs.isIdentical(to:rhs)
     }
+    ///
+    /// Whether `self` and `other` are the same *number*.
+    ///
+    /// `init(scale:mantissa:)` normalizes -- it moves the mantissa's trailing zeros
+    /// into the scale -- so a value built through it is settled by the identity
+    /// check below.  Two things break that invariant, and neither requires doing
+    /// anything unusual:
+    ///
+    ///  *  `truncate(width:)` rounds the mantissa in place, zeroing its low bits
+    ///     without moving them into the scale.  `BigFloat.SQRT2(precision: 128)`
+    ///     comes back as a 641-bit mantissa with 512 trailing zeros, where
+    ///     `BigFloat.sqrt(BigFloat(2))` -- the same number -- has 129 bits.
+    ///  *  `scale` and `mantissa` are settable `public var`s, so any caller can
+    ///     denormalize a value. That alone rules out representation equality.
+    ///
+    /// This was `isIdentical(to:)` outright, which called those two values unequal.
+    /// The consequence was worse than a wrong answer: `<`, `==` and `>` were *all*
+    /// false for them, and `Comparable` requires exactly one to hold.  `isLess
+    /// (than:)` compares by subtraction and was right the whole time, so `==` was
+    /// the only liar.
+    ///
     public func isEqual(to other:BigFloat)->Bool {
-        return self.isNaN || other.isNaN ? false
-          :  self.isZero ? other.isZero
-          :  self.isIdentical(to: other)
+        if self.isNaN || other.isNaN { return false }
+        if self.isIdentical(to: other) { return true }
+        // ±0 equal each other and nothing else.  ±∞ equal only themselves, which
+        // the identity check has already settled, there being one spelling of each.
+        if self.isZero || other.isZero { return self.isZero && other.isZero }
+        if self.isInfinite || other.isInfinite { return false }
+        // Finite and non-zero on both sides: compare what `init(scale:mantissa:)`
+        // would have stored, without building it.
+        let ls = self.mantissa.trailingZeroBitCount
+        let rs = other.mantissa.trailingZeroBitCount
+        return self.scale + ls == other.scale + rs
+          &&   self.mantissa >> ls == other.mantissa >> rs
     }
     public static func ==(_ lhs:BigFloat, _ rhs:BigFloat)->Bool {
         return lhs.isEqual(to:rhs)
+    }
+    /// `Hashable` asks that equal values hash equally, so this hashes the
+    /// normalized form for the same reason `isEqual(to:)` compares it.  The
+    /// synthesized conformance hashed the stored properties, which put the same
+    /// number in two buckets.
+    ///
+    /// ±0 have to agree, being `==`.  NaN needs no care -- it equals nothing,
+    /// itself included -- but keeping the two spellings apart costs nothing.
+    public func hash(into hasher: inout Hasher) {
+        if self.isNaN  { hasher.combine(Int.max) ; hasher.combine(mantissa) ; return }
+        if self.isZero { hasher.combine(0) ; hasher.combine(Significand.zero) ; return }
+        let shift = mantissa.trailingZeroBitCount
+        hasher.combine(scale + shift)
+        hasher.combine(mantissa >> shift)
     }
 }
 /// comparison.  Now we need infinity and isInfinite

--- a/Sources/BigNum/Rational.swift
+++ b/Sources/BigNum/Rational.swift
@@ -140,25 +140,75 @@ extension RationalType {
     public var isSignalingNaN:Bool  { return self.isNaN }
     public var isCanonical:Bool     { return true }
     //
+    /// Whether `self` and `other` are stored the same way -- a stronger question
+    /// than `==`, since one number has many spellings as a fraction.
     public func isIdentical(to other: Self) -> Bool {
         return self.num == other.num && self.den == other.den
     }
+    ///
+    /// Whether `self` and `other` are the same *number*.
+    ///
+    /// `init(_:_:)` reduces, so a value built through it is settled by the identity
+    /// check below and nothing further is spent.  But `init(num:den:)` is a
+    /// requirement of this protocol and stores what it is given, `num` and `den` are
+    /// settable, and conversions use them -- `BigRat(someBigFloat)` writes
+    /// `mantissa / 2^-scale` without reducing.  So an unreduced value is ordinary,
+    /// not pathological, and representation equality cannot answer this.
+    ///
+    /// This was `isIdentical(to:)` outright, which called 2/4 and 1/2 unequal
+    /// whenever the first arrived without being reduced.  Worse, `<`, `==` and `>`
+    /// were then *all* false for one number, and `Comparable` requires exactly one
+    /// to hold.
+    ///
+    /// Cross-multiplication settles it, and is what `isLessThan` already pays for
+    /// every unequal pair.  It does not care about the sign of either denominator:
+    /// `-1/-2` and `1/2` give the same products.
+    ///
     public func isEqual(to other: Self) -> Bool {
-        return self.isNaN || other.isNaN ? false
-          :  self.isZero ? other.isZero
-          :  self.isIdentical(to: other)
+        if self.isNaN || other.isNaN { return false }
+        if self.isIdentical(to: other) { return true }
+        if self.isZero || other.isZero { return self.isZero && other.isZero }
+        if self.isInfinite || other.isInfinite {
+            return self.isInfinite && other.isInfinite && self.sign == other.sign
+        }
+        return self.num * other.den == other.num * self.den
+    }
+    /// `Hashable` asks that equal values hash equally, so this hashes what
+    /// `init(_:_:)` would have stored.  The synthesized conformance hashed `num` and
+    /// `den` as they lay, which put one number in two buckets -- and a `Set` then
+    /// holds it twice.
+    ///
+    /// The reduction costs a gcd, paid only when hashing and not when comparing.
+    /// ±0 have to agree, being `==`; NaN equals nothing, itself included, so its
+    /// hash is free to be anything.
+    public func hash(into hasher: inout Hasher) {
+        if self.isZero     { hasher.combine(0) ; hasher.combine(0) ; return }
+        if self.isNaN      { hasher.combine(1) ; hasher.combine(0) ; return }
+        if self.isInfinite { hasher.combine(2) ; hasher.combine(self.sign == .minus ? -1 : 1) ; return }
+        var (n, d) = den < 0 ? (-num, -den) : (num, den)
+        let g = n.greatestCommonDivisor(with: d)
+        if g != 1 { n /= g ; d /= g }
+        hasher.combine(n)
+        hasher.combine(d)
     }
     private func isLessThan(_ other:Self, onEqual:Bool)->Bool {
-        if self.isEqual(to: other) { return onEqual }
         if self.isNaN || other.isNaN { return false }
+        if self.isIdentical(to: other) { return onEqual }
+        if self.isZero && other.isZero { return onEqual }
         if self.isInfinite {
+            // two infinities of one sign are equal, which the identity check above
+            // only catches when they are spelled the same way
+            if other.isInfinite && self.sign == other.sign { return onEqual }
             return self.sign == .minus
         }
         if other.isInfinite {
             return other.sign == .plus
         }
+        // Equality falls out of the same two products, so this does not call
+        // `isEqual(to:)` and pay for them twice.
         let l = self.num * other.den
         let r = other.num * self.den
+        if l == r { return onEqual }
         return self.den.signum() * other.den.signum() < 0 ? r < l : l < r
     }
     public func isLess(than other: Self) -> Bool {

--- a/SwiftNumericsExample/.gitignore
+++ b/SwiftNumericsExample/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/SwiftNumericsExample/Package.swift
+++ b/SwiftNumericsExample/Package.swift
@@ -1,0 +1,49 @@
+// swift-tools-version: 6.3
+//
+// A demo of using BigNum alongside apple/swift-numerics, and a package of its own
+// so that swift-bignum's root manifest keeps its no-dependencies property -- see
+// Benchmarks/Package.swift, which is separate for the same reason.
+//
+//     cd SwiftNumericsExample && swift test
+//
+// The parent is a `path:` dependency, not a `url:` one.  A URL pointing at `..`
+// makes SwiftPM clone the parent as a git working copy and resolve it to a
+// *committed* revision, so uncommitted work in the checkout you are sitting in is
+// invisible to the demo.  `path:` reads the directory itself, which is what a
+// sibling demo wants.
+//
+// Its package identity is `swift-bignum`, from the directory name rather than from
+// the `name: "BigNum"` in its manifest -- that is what `.product(package:)` below
+// has to match.
+//
+import PackageDescription
+
+let package = Package(
+    name: "SwiftNumericsExample",
+    products: [
+        .library(
+            name: "SwiftNumericsExample",
+            targets: ["SwiftNumericsExample"]
+        ),
+    ],
+    dependencies: [
+      .package(url:"https://github.com/apple/swift-numerics", from:"1.0.0"),
+      .package(path:".."),
+    ],
+    targets: [
+        // Products from another package need `.product(name:package:)`; a bare
+        // string names a target in *this* package, which is why "BigNum" alone
+        // came back as "product 'BigNum' ... not found".
+        .target(
+            name: "SwiftNumericsExample",
+            dependencies: [
+                .product(name: "BigNum", package: "swift-bignum"),
+                .product(name: "RealModule", package: "swift-numerics"),
+                .product(name: "ComplexModule", package: "swift-numerics"),
+            ]),
+        .testTarget(
+            name: "SwiftNumericsExampleTests",
+            dependencies: ["SwiftNumericsExample"]),
+    ],
+     swiftLanguageModes: [.v6]
+)

--- a/SwiftNumericsExample/Sources/SwiftNumericsExample/BigNumBridge.swift
+++ b/SwiftNumericsExample/Sources/SwiftNumericsExample/BigNumBridge.swift
@@ -1,0 +1,59 @@
+//
+//  BigNumBridge.swift -- reaching BigNum's own implementations without looping.
+//
+//  This file imports BigNum and *not* RealModule, so BigNum's names mean BigNum's
+//  here.  That alone is not enough, and the reason is worth spelling out.
+//
+//  NumericsConformance.swift declares `sqrt`, `exp10`, `reciprocal` and
+//  `signGamma` directly on `BigRat` and `BigFloat`, because each has a default
+//  implementation in *both* protocol hierarchies and a requirement with two
+//  equally good witnesses is unsatisfied.  A member on the concrete type outranks
+//  a protocol-extension default -- which is what makes it work, and also what
+//  makes the obvious delegation a trap: those four are requirements of BigNum's
+//  `ElementaryFunctions`/`RealFunctions` too, so the concrete member becomes
+//  *BigNum's* witness as well.  `BigRat.sqrt(x)` from here would land back on the
+//  witness that called it.  It compiles, and it recurses until the stack ends.
+//
+//  So nothing below calls a one-argument form.  BigNum gives every function a
+//  `precision:`-taking twin, and those are ordinary extension members rather than
+//  protocol requirements -- a different signature, no dispatch, no way back to the
+//  witness.  `sqrt(x)` in BigNum is exactly `sqrt(x, precision: Self.precision,
+//  debug: false)` (ElementaryFunctions.swift:927), which is what these call, so
+//  the behaviour is the library's own and not a reimplementation of it.
+//
+import BigNum
+
+/// √x, at BigNum's default precision -- the `precision:` overload, so this cannot
+/// resolve to the one-argument witness that calls it.
+@inline(__always) func bignum_sqrt<T:BigFloatingPoint>(_ x: T) -> T {
+    return T.sqrt(x, precision: T.precision, debug: false)
+}
+
+/// 10^x.  BigNum's `exp10` is `pow(10, x)` and has no `precision:` twin of its
+/// own, so this goes to `pow`'s -- which we do not declare, so it is unambiguous.
+@inline(__always) func bignum_exp10<T:BigFloatingPoint>(_ x: T) -> T {
+    return T.pow(10, x, precision: T.precision, debug: false)
+}
+
+/// The sign of Γ(x).
+///
+/// The one member here that *is* reimplemented, because BigNum's lives only as a
+/// default on its `Real` and has no differently-shaped twin to call.  Kept
+/// equivalent to Real.swift:71: Γ is negative exactly between the odd negative
+/// integers, and at a negative integer it has a pole rather than a sign change.
+/// The parity test avoids `radix` and `addingProduct`, so it reads the same for a
+/// rational as for a float.
+@inline(__always) func bignum_signGamma<T:FloatingPoint>(_ x: T) -> FloatingPointSign {
+    if x >= 0 { return .plus }
+    let trunc = x.rounded(.towardZero)
+    if x == trunc { return .plus }              // a pole, not a sign change
+    let half = (trunc / 2).rounded(.towardZero)
+    return half * 2 == trunc ? .minus : .plus
+}
+
+/// a/b for a rational, by the method behind BigNum's own `/`
+/// (`RationalType.over(_:)`), since `/` itself is declared on the concrete type in
+/// NumericsConformance.swift and would come straight back here.
+@inline(__always) func bignum_divide(_ a: BigRat, _ b: BigRat) -> BigRat {
+    return a.over(b)
+}

--- a/SwiftNumericsExample/Sources/SwiftNumericsExample/NumericsConformance.swift
+++ b/SwiftNumericsExample/Sources/SwiftNumericsExample/NumericsConformance.swift
@@ -1,0 +1,80 @@
+//
+//  NumericsConformance.swift -- BigRat and BigFloat as swift-numerics `Real`s, so
+//  that `Complex<BigRat>` and `Complex<BigFloat>` work.
+//
+//  `Complex<RealType>` requires `RealType: RealModule.Real`, and BigNum's types
+//  conform to BigNum's own `Real` instead -- same requirement set, different
+//  protocol.  Every method swift-numerics asks for is already there under the same
+//  name with the same signature; the compiler says so, in as many words:
+//
+//      note: candidate exactly matches
+//
+//  What it says next is the problem:
+//
+//      error: type 'BigFloat' does not conform to protocol 'AlgebraicField'
+//      note: multiple matching properties named 'reciprocal' with type 'BigFloat?'
+//
+//  Four members -- `sqrt`, `exp10`, `reciprocal`, `signGamma` -- have a default in
+//  each hierarchy, plus `/` for `BigRat` alone, whose `/` comes from a protocol
+//  extension where `BigFloat`'s is on the struct.  Two equally specific candidates
+//  do not overload a requirement, they leave it unsatisfied.  A member declared on
+//  the concrete type outranks both, which is why those five are written out below;
+//  the other thirty-odd requirements need nothing.  See BigNumBridge.swift for why
+//  their bodies do not simply call BigNum by name.
+//
+//  This lives in the example package rather than in BigNum on purpose.  BigNum's
+//  manifest has no dependencies -- Real.swift exists precisely so that it needs
+//  none -- and taking on swift-numerics to hand a conformance back would undo that.
+//  A retroactive conformance costs the library nothing, and anyone wanting
+//  `Complex` over these types can copy these two files.
+//
+import BigNum
+import RealModule
+
+// MARK: - BigRat
+
+extension BigRat {
+    /// √x.  The static spelling both `Real`s require; here to outrank the two
+    /// defaults rather than to add anything.
+    public static func sqrt(_ x: BigRat) -> BigRat { return bignum_sqrt(x) }
+    /// 10^x
+    public static func exp10(_ x: BigRat) -> BigRat { return bignum_exp10(x) }
+    /// The sign of Γ(x), which `logGamma` drops by taking |Γ|.
+    public static func signGamma(_ x: BigRat) -> FloatingPointSign {
+        return bignum_signGamma(x)
+    }
+    /// 1/self, or nil when that is not representable -- so a caller may substitute
+    /// `x * y.reciprocal!` for `x / y` without losing accuracy.
+    public var reciprocal: BigRat? {
+        let recip = 1/self
+        if recip.isNormal || isZero || !isFinite { return recip }
+        return nil
+    }
+    /// a/b.  `BigFloat` needs no equivalent: its `/` is declared on the struct and
+    /// already outranks `AlgebraicField`'s default, where a rational's comes from
+    /// `extension RationalType` and merely ties with it.
+    public static func / (a: BigRat, b: BigRat) -> BigRat { return bignum_divide(a, b) }
+}
+
+extension BigRat: RealModule.Real {}
+
+// MARK: - BigFloat
+
+extension BigFloat {
+    /// √x -- see `BigRat.sqrt(_:)` for why this is spelled out.
+    public static func sqrt(_ x: BigFloat) -> BigFloat { return bignum_sqrt(x) }
+    /// 10^x
+    public static func exp10(_ x: BigFloat) -> BigFloat { return bignum_exp10(x) }
+    /// The sign of Γ(x).
+    public static func signGamma(_ x: BigFloat) -> FloatingPointSign {
+        return bignum_signGamma(x)
+    }
+    /// 1/self, or nil when that is not representable.
+    public var reciprocal: BigFloat? {
+        let recip = 1/self
+        if recip.isNormal || isZero || !isFinite { return recip }
+        return nil
+    }
+}
+
+extension BigFloat: RealModule.Real {}

--- a/SwiftNumericsExample/Sources/SwiftNumericsExample/SwiftNumericsExample.swift
+++ b/SwiftNumericsExample/Sources/SwiftNumericsExample/SwiftNumericsExample.swift
@@ -1,0 +1,58 @@
+//
+//  SwiftNumericsExample.swift -- BigNum and apple/swift-numerics together.
+//
+//  What this package is for: `Complex<BigRat>` and `Complex<BigFloat>`.
+//  NumericsConformance.swift is the part that makes them compile; this file is what
+//  they are good for.
+//
+//  Everything printed here is asserted in the test suite, so the comments are
+//  checked rather than claimed.
+//
+import BigNum
+import ComplexModule
+// RealModule too, and not only for tidiness: `Complex<Double>` below needs
+// `Double: RealModule.Real`, and a conformance is only usable in a file that
+// imports the module declaring it.  Without this line the compiler says so --
+// "cannot use conformance of 'Double' to 'Real' here".
+import RealModule
+
+/// Complex division over an *exact* type.
+///
+/// `(1+2i)/(3+4i)` is `(11+2i)/25` -- 0.44 + 0.08i -- and 25 is not a power of two,
+/// so no binary float lands on either component.  Over `BigRat` the answer is the
+/// number itself, and multiplying back returns exactly what you started with.
+public func exactComplexDivision() -> (quotient: Complex<BigRat>, roundTrips: Bool) {
+    let q = Complex<BigRat>(1, 2) / Complex<BigRat>(3, 4)
+    return (q, q * Complex<BigRat>(3, 4) == Complex<BigRat>(1, 2))
+}
+
+/// Complex transcendentals at more precision than a `Double` has.
+///
+/// `exp(iπ) == -1` is the whole chain: `Complex.exp` calls `BigFloat`'s `cos` and
+/// `sin`, which reduce by π, which comes from `ATAN1`.  At BigNum's default 128 bits
+/// both components land about 1e-39 from where they should be, where a `Double`'s
+/// imaginary part is 1.22e-16 out and cannot do better.
+public func eulerIdentity() -> (bigFloat: Complex<BigFloat>, double: Complex<Double>) {
+    return (Complex<BigFloat>.exp(Complex<BigFloat>(0, BigFloat.pi)),
+            Complex<Double>.exp(Complex<Double>(0, Double.pi)))
+}
+
+/// √i = (1+i)/√2, over `BigFloat`.
+public func squareRootOfI() -> Complex<BigFloat> {
+    return Complex<BigFloat>.sqrt(Complex<BigFloat>.i)
+}
+
+/// Prints the three above.  Not a test -- `swift test` is where the checking is.
+public func demo() {
+    let (q, roundTrips) = exactComplexDivision()
+    print("Complex<BigRat>: (1+2i)/(3+4i) = \(q.real.toString()) + \(q.imaginary.toString())i")
+    print("                exact 11/25 and 2/25? \(q.real == BigRat(11, 25) && q.imaginary == BigRat(2, 25))")
+    print("                multiplies back exactly? \(roundTrips)")
+
+    let (bf, d) = eulerIdentity()
+    print("Complex<BigFloat>: exp(iπ) off by  re \((bf.real + 1).magnitude.toDouble()), im \(bf.imaginary.magnitude.toDouble())")
+    print("Complex<Double>:   exp(iπ) off by  re \((d.real + 1).magnitude), im \(d.imaginary.magnitude)")
+
+    let r = squareRootOfI()
+    print("Complex<BigFloat>: √i = \(r.real.toDouble()) + \(r.imaginary.toDouble())i")
+}

--- a/SwiftNumericsExample/Tests/SwiftNumericsExampleTests/SwiftNumericsExampleTests.swift
+++ b/SwiftNumericsExample/Tests/SwiftNumericsExampleTests/SwiftNumericsExampleTests.swift
@@ -1,0 +1,226 @@
+import Testing
+import BigNum
+import ComplexModule
+import Foundation
+@testable import SwiftNumericsExample
+
+///
+/// `Complex<BigRat>` and `Complex<BigFloat>`, which is the point of this package.
+///
+/// The conformances they rest on are five members declared on the concrete types
+/// to break a tie between two protocol hierarchies -- see NumericsConformance.swift.
+/// Two things therefore need testing that would not otherwise:
+///
+///  *  that the five do not recurse.  Declaring `sqrt` on `BigFloat` makes it
+///     BigNum's witness as well as swift-numerics', so a body that called
+///     `BigFloat.sqrt` would come back to itself.  That compiles.  Every one of the
+///     five is called directly below, and a stack overflow is a failed test run
+///     rather than a wrong number.
+///  *  that they still mean what BigNum means.  A witness that outranks the
+///     library's own default is a chance to change behaviour by accident.
+///
+@Suite struct ConformanceTests {
+
+    /// The five tie-breakers, called directly.  If any recursed this test would not
+    /// return.
+    @Test func theTieBreakersTerminateAndAgreeWithBigNum() {
+        // sqrt
+        #expect(BigRat.sqrt(BigRat(4)) == 2)
+        #expect(BigFloat.sqrt(BigFloat(4)) == 2)
+        // √2 against BigNum's own answer at BigNum's default precision.  128 is
+        // written out because *reading* `BigRat.precision` is an error under Swift 6
+        // strict concurrency -- it is a mutable `static var`.
+        //
+        // Compared by subtraction, not `==`: for `BigFloat` those two carry the same
+        // number in different mantissa widths, and `BigFloat.==` looks at the storage.
+        // See `bigFloatEqualityLooksAtStorageNotValue` below.
+        #expect(BigRat.sqrt(BigRat(2)) == BigRat.SQRT2(precision: 128))
+        #expect((BigFloat.sqrt(BigFloat(2)) - BigFloat.SQRT2(precision: 128)).isZero)
+        // exp10
+        #expect(BigRat.exp10(BigRat(2)) == 100)
+        #expect(BigFloat.exp10(BigFloat(3)) == 1000)
+        // reciprocal -- exact for a rational
+        #expect(BigRat(4).reciprocal == BigRat(1, 4))
+        #expect(BigFloat(4).reciprocal == BigFloat(0.25))
+        #expect(BigRat.zero.reciprocal?.isInfinite == true, "zero has a reciprocal where there is an infinity")
+        // signGamma: Γ is negative between the odd negative integers
+        #expect(BigRat.signGamma(BigRat(3)) == .plus)
+        #expect(BigRat.signGamma(BigRat(-1, 2)) == .minus, "-0.5 lies in (-1, 0)")
+        #expect(BigRat.signGamma(BigRat(-3, 2)) == .plus, "-1.5 lies in (-2, -1)")
+        #expect(BigRat.signGamma(BigRat(-5, 2)) == .minus)
+        #expect(BigRat.signGamma(BigRat(-2)) == .plus, "a pole, not a sign change")
+        #expect(BigFloat.signGamma(BigFloat(-0.5)) == .minus)
+        #expect(BigFloat.signGamma(BigFloat(-1.5)) == .plus)
+        // and it agrees with Double's, which comes from the same logic
+        for x in [3.0, -0.5, -1.5, -2.5, -2.0, 0.0, 7.25, -7.25] {
+            #expect(BigFloat.signGamma(BigFloat(x)) == (tgamma(x) < 0 ? .minus : .plus), "signGamma(\(x))")
+        }
+        // division
+        #expect(BigRat(1) / BigRat(4) == BigRat(1, 4))
+        #expect(BigRat(-7) / BigRat(2) == BigRat(-7, 2))
+    }
+
+    /// Exact where `Double` cannot be: a rational's `/` divides rather than rounds.
+    @Test func rationalDivisionStaysExact() {
+        let third = BigRat(1) / BigRat(3)
+        #expect(third * 3 == 1, "1/3 * 3 == 1 exactly, which no binary float manages")
+        #expect(BigRat(1, 10) + BigRat(2, 10) == BigRat(3, 10), "0.1 + 0.2 == 0.3")
+        #expect(0.1 + 0.2 != 0.3, "as Double, famously, does not")
+    }
+}
+
+///
+/// The arithmetic, over both types, checked against values that are exact in binary
+/// so that agreement is agreement and not luck.
+///
+@Suite struct ComplexTests {
+
+    @Test func arithmeticOverBigRat() {
+        let a = Complex<BigRat>(1, 2)
+        let b = Complex<BigRat>(3, 4)
+        #expect(a + b == Complex<BigRat>(4, 6))
+        #expect(a - b == Complex<BigRat>(-2, -2))
+        #expect(a * b == Complex<BigRat>(-5, 10))
+        #expect(Complex<BigRat>.i * Complex<BigRat>.i == Complex<BigRat>(-1, 0), "i² == -1")
+    }
+
+    @Test func arithmeticOverBigFloat() {
+        let a = Complex<BigFloat>(1, 2)
+        let b = Complex<BigFloat>(3, 4)
+        #expect(a + b == Complex<BigFloat>(4, 6))
+        #expect(a - b == Complex<BigFloat>(-2, -2))
+        #expect(a * b == Complex<BigFloat>(-5, 10))
+        #expect(Complex<BigFloat>.i * Complex<BigFloat>.i == Complex<BigFloat>(-1, 0), "i² == -1")
+    }
+
+    /// Division is where an exact type earns its keep: (1+2i)/(3+4i) is
+    /// (11+2i)/25 = 0.44 + 0.08i, and neither 0.44 nor 0.08 is a binary fraction.
+    @Test func divisionIsExactOverBigRat() {
+        let q = Complex<BigRat>(1, 2) / Complex<BigRat>(3, 4)
+        #expect(q == Complex<BigRat>(BigRat(11, 25), BigRat(2, 25)),
+                "got \(q.real.toString()) + \(q.imaginary.toString())i")
+        // and it round-trips, which a rounding division would not
+        #expect(q * Complex<BigRat>(3, 4) == Complex<BigRat>(1, 2))
+        // `Double` has no 11/25 to land on -- 25 is not a power of two -- so its
+        // answer is the nearest Double to 0.44 and not the number itself.
+        // Converting back to an exact rational is what shows it; the round trip
+        // does *not*, because this particular multiply happens to round back.
+        let qd = Complex<Double>(1, 2) / Complex<Double>(3, 4)
+        #expect(BigRat(qd.real) != BigRat(11, 25), "Double's 0.44 is not 11/25")
+        #expect(BigRat(qd.imaginary) != BigRat(2, 25), "nor its 0.08 2/25")
+        #expect(qd * Complex<Double>(3, 4) == Complex<Double>(1, 2),
+                "it does round-trip here, which is luck rather than exactness")
+    }
+
+    /// Both types agree with `Double` on values a `Double` represents exactly.
+    @Test func agreesWithDoubleWhereDoubleIsExact() {
+        for (re, im) in [(1.0, 2.0), (-3.0, 0.5), (0.0, -1.0), (2.5, -4.25)] {
+            let zr = Complex<BigRat>(BigRat(re), BigRat(im))
+            let zf = Complex<BigFloat>(BigFloat(re), BigFloat(im))
+            let zd = Complex<Double>(re, im)
+            let w = Complex<Double>(1.5, -2.0)
+            let wr = Complex<BigRat>(BigRat(1.5), BigRat(-2.0))
+            let wf = Complex<BigFloat>(BigFloat(1.5), BigFloat(-2.0))
+            #expect((zr * wr).real.toDouble() == (zd * w).real, "real of product at \(re),\(im)")
+            #expect((zr * wr).imaginary.toDouble() == (zd * w).imaginary)
+            #expect((zf * wf).real.toDouble() == (zd * w).real)
+            #expect((zf * wf).imaginary.toDouble() == (zd * w).imaginary)
+        }
+    }
+
+    /// The transcendentals, which is what needed `Real` rather than just a field.
+    /// `exp(iπ) == -1` is the check that reaches all the way down to `ATAN1`.
+    @Test func transcendentalsOverBigFloat() {
+        let pi = BigFloat.pi
+        let z = Complex<BigFloat>.exp(Complex<BigFloat>(0, pi))
+        // 128 bits, so a hair either side of -1 rather than exactly it
+        let tol = BigFloat.getEpsilon(precision: 100)
+        #expect((z.real - (-1)).magnitude < tol, "Re exp(iπ) = \(z.real), want -1")
+        #expect(z.imaginary.magnitude < tol, "Im exp(iπ) = \(z.imaginary), want 0")
+        // √i = (1+i)/√2
+        let root = Complex<BigFloat>.sqrt(Complex<BigFloat>.i)
+        let half = BigFloat.sqrt(BigFloat(2)) / 2
+        #expect((root.real - half).magnitude < tol)
+        #expect((root.imaginary - half).magnitude < tol)
+        // log(e) == 1
+        let one = Complex<BigFloat>.log(Complex<BigFloat>(BigFloat.exp(1), 0))
+        #expect((one.real - 1).magnitude < tol)
+    }
+
+    /// The reason to want this over `Complex<Double>`: precision that does not run
+    /// out.  Even at BigNum's default 128 bits, `exp(iπ)` lands far closer to -1
+    /// than a `Double` can express.
+    ///
+    /// Raising the precision would show more, and cannot be demonstrated here:
+    /// `BigFloat.precision = 512` is an error in Swift 6 language mode, because it
+    /// is a mutable `static var`.  Reading it is an error too.
+    @Test func precisionGoesFurtherThanDouble() {
+        let z = Complex<BigFloat>.exp(Complex<BigFloat>(0, BigFloat.pi))
+        let zd = Complex<Double>.exp(Complex<Double>(0, Double.pi))
+        // Double: sin(π) is ~1.22e-16 away from 0 and cannot be closer
+        #expect(zd.imaginary.magnitude > 1e-17, "Double's error in Im exp(iπ)")
+        #expect(zd.imaginary.magnitude < 1e-15)
+        // BigFloat at 128 bits: past where a Double has any bits left
+        #expect(z.imaginary.magnitude < BigFloat.getEpsilon(precision: 100))
+        #expect(BigFloat.getEpsilon(precision: 100).toDouble() < 1e-30,
+                "the bar just cleared is below anything a Double can express")
+    }
+}
+
+///
+/// A defect in BigNum that this exercise turned up, in both `BigFloat` and `BigRat`,
+/// now fixed in both.  It matters here because `Complex` compares its `RealType`.
+///
+@Suite struct EqualityAcrossRepresentations {
+
+    /// `BigFloat.==` used to be `isIdentical(to:)` -- `scale` and `mantissa` -- which
+    /// made two spellings of one number unequal and left `<`, `==` and `>` all false,
+    /// something `Comparable` forbids.  It compares values now.
+    ///
+    /// It matters here because `Complex` compares its `RealType`.
+    @Test func bigFloatComparesValuesNotStorage() {
+        let a = BigFloat.sqrt(BigFloat(2))          // 129-bit mantissa
+        let b = BigFloat.SQRT2(precision: 128)      // 641 bits, low 512 of them zero
+        #expect((a - b).isZero, "the same number, two representations")
+        #expect(a.description == b.description, "and they print the same")
+        #expect(a == b)
+        #expect(a.hashValue == b.hashValue)
+        #expect(!(a === b), "`===` still reports the storage differs")
+        #expect([a < b, a == b, a > b].filter { $0 }.count == 1, "exactly one holds")
+    }
+
+    /// `BigRat` had the same defect and the same fix.  On its own terms the type was
+    /// always sound -- it reduces on construction -- but `BigRat(someBigFloat)` builds
+    /// `mantissa / 2^-scale` without reducing, and `init(num:den:)` stores whatever it
+    /// is given.  `==` cross-multiplies now.
+    @Test func bigRatComparesValuesNotFractions() {
+        let ra = BigRat(BigFloat.sqrt(BigFloat(2)))
+        let rb = BigRat(BigFloat.SQRT2(precision: 128))
+        #expect((ra - rb).isZero, "the same number")
+        #expect(ra.den.bitWidth != rb.den.bitWidth, "129 bits against 641")
+        #expect(ra == rb)
+        #expect(ra.hashValue == rb.hashValue)
+        #expect(!ra.isIdentical(to: rb), "and the fractions still differ")
+        #expect([ra < rb, ra == rb, ra > rb].filter { $0 }.count == 1, "exactly one holds")
+        // sound where it always was
+        #expect(BigRat(2, 4) == BigRat(1, 2))
+        #expect(BigRat(1, 3) + BigRat(1, 6) == BigRat(1, 2))
+    }
+}
+
+/// The demo entry points, so that what the README shows is what runs.
+@Suite struct DemoTests {
+    @Test func demoFunctionsAgreeWithTheirComments() {
+        let (q, roundTrips) = exactComplexDivision()
+        #expect(q.real == BigRat(11, 25) && q.imaginary == BigRat(2, 25))
+        #expect(roundTrips)
+        let (bf, d) = eulerIdentity()
+        #expect((bf.real + 1).magnitude.toDouble() < 1e-38, "about 1e-39, per the comment")
+        #expect(bf.imaginary.magnitude.toDouble() < 1e-38)
+        #expect(d.imaginary.magnitude > 1e-17 && d.imaginary.magnitude < 1e-15, "1.22e-16")
+        let r = squareRootOfI()
+        #expect(r.real.toDouble() == 0.7071067811865476)
+        #expect(r.imaginary.toDouble() == 0.7071067811865476)
+        demo()
+    }
+}

--- a/Tests/BigNumOperatorsTests/ExponentiationTests.swift
+++ b/Tests/BigNumOperatorsTests/ExponentiationTests.swift
@@ -76,9 +76,19 @@ import BigNumOperators
         // near enough to be a rounding difference and no more
         let err = (BigRat(1,3) ** 2 - BigRat(1,9)).magnitude
         #expect(err < BigRat.getEpsilon(precision: 120), "\(err) should be a 128-bit rounding")
-        // BigFloat rounds too, and prints as though it had not
+        // BigFloat rounds too: √3 is irrational, so squaring what `pow` returns
+        // does not get 3 back
+        let r = BigFloat.pow(BigFloat(3), BigFloat(0.5))
+        #expect(r * r != 3, "pow rounds to 128 bits")
+        #expect((r * r - 3).magnitude < BigFloat.getEpsilon(precision: 120),
+                "and the miss is that rounding and nothing more")
+        // Where the answer *is* representable, `pow` lands on it exactly.  This
+        // used to read `!= 2`, "which is worth knowing" -- and what it knew was a
+        // bug: `pow(4, 0.5)` is 2, stored as 2⁷⁶³ × 2⁻⁷⁶² because `truncate(width:)`
+        // zeroes low mantissa bits without renormalizing, and `BigFloat.==`
+        // compared the representation.  See `BigFloat.isEqual(to:)`.
+        #expect(BigFloat.pow(BigFloat(4), BigFloat(0.5)) == 2)
         #expect(BigFloat.pow(BigFloat(4), BigFloat(0.5)).description == "2.0")
-        #expect(BigFloat.pow(BigFloat(4), BigFloat(0.5)) != 2, "which is worth knowing")
     }
 
     /// Which overload a bare literal picks.  `2 ** 3` has four candidates -- Int

--- a/Tests/BigNumTests/BigNumTests.swift
+++ b/Tests/BigNumTests/BigNumTests.swift
@@ -166,3 +166,174 @@ import Testing
         }
     }
 }
+
+///
+/// `BigFloat`'s `==` is IEEE equality, not representation equality.
+///
+/// The distinction is not academic: `truncate(width:)` rounds the mantissa in place
+/// without moving the zeroed bits into the scale, so ordinary API hands back the
+/// same number in more than one shape.  `init(scale:mantissa:)` normalizes, `<`
+/// compares by subtraction, and `==` used to compare the stored properties -- which
+/// left `<`, `==` and `>` all false for a pair of equal values, something
+/// `Comparable` forbids.
+///
+@Suite struct BigFloatEqualityTests {
+
+    /// The pair that found it.  √2 at 129 bits against √2 at 641 bits, the latter
+    /// being the 640-bit seed with its low 512 bits rounded away but still stored.
+    @Test func theSameNumberInTwoWidthsIsEqual() {
+        let a = BigFloat.sqrt(BigFloat(2))
+        let b = BigFloat.SQRT2(precision: 128)
+        #expect(a.mantissa.bitWidth != b.mantissa.bitWidth, "two shapes")
+        #expect((a - b).isZero, "one number")
+        #expect(a == b)
+        #expect(!(a === b), "`===` still reports the shapes differ, which is its job")
+        #expect(a.hashValue == b.hashValue, "equal values, equal hashes")
+        #expect(a <= b && a >= b)
+        #expect([a < b, a == b, a > b].filter { $0 }.count == 1,
+                "exactly one of <, == and > -- this is the contract that was broken")
+    }
+
+    /// `pow` returns values of the same padded shape, which is how a test in this
+    /// package came to assert that `pow(4, 0.5) != 2`.  It is 2, stored as
+    /// 2⁷⁶³ × 2⁻⁷⁶².
+    @Test func powLandsExactlyOnRepresentableAnswers() {
+        let two = BigFloat.pow(BigFloat(4), BigFloat(0.5))
+        #expect(two == 2)
+        #expect(two.hashValue == BigFloat(2).hashValue)
+        #expect(!(two === BigFloat(2)), "same number, and stored with 762 spare bits")
+    }
+
+    /// `scale` and `mantissa` are settable `public var`s, so a caller can denormalize
+    /// a value directly.  That on its own rules out representation equality.
+    @Test func denormalizingByHandDoesNotChangeTheNumber() {
+        var padded = BigFloat(1)
+        padded.mantissa <<= 64
+        padded.scale -= 64
+        #expect(padded == BigFloat(1))
+        #expect(padded.hashValue == BigFloat(1).hashValue)
+        #expect(!(padded === BigFloat(1)))
+        #expect([padded < 1, padded == 1, padded > 1].filter { $0 }.count == 1)
+    }
+
+    /// The IEEE cases BigFloat.md promises, which the fix had to leave alone.
+    @Test func theIEEECasesStillHold() {
+        #expect(BigFloat(0) == -BigFloat(0), "the two zeros are equal")
+        #expect(!(BigFloat(0) === -BigFloat(0)), "and stored differently")
+        #expect(BigFloat(0).hashValue == (-BigFloat(0)).hashValue, "so they must hash alike")
+        #expect(BigFloat.nan != BigFloat.nan)
+        #expect(BigFloat.nan === BigFloat.nan)
+        #expect(BigFloat.infinity == BigFloat.infinity)
+        #expect(-BigFloat.infinity == -BigFloat.infinity)
+        #expect(BigFloat.infinity != -BigFloat.infinity)
+        #expect(BigFloat.infinity != BigFloat(1))
+        #expect(BigFloat.infinity != BigFloat(0))
+    }
+
+    /// A `Set` is where a broken hash shows up as a wrong count rather than a wrong
+    /// comparison.
+    @Test func aSetHoldsEachNumberOnce() {
+        let s: Set<BigFloat> = [BigFloat.sqrt(BigFloat(2)), BigFloat.SQRT2(precision: 128),
+                                BigFloat.pow(BigFloat(4), BigFloat(0.5)), BigFloat(2),
+                                BigFloat(0), -BigFloat(0)]
+        #expect(s.count == 3, "√2, 2 and zero -- got \(s.count)")
+    }
+
+    /// Different numbers stay different, whatever widths they are carrying.
+    @Test func differentNumbersStayDifferent() {
+        let wide = BigFloat.SQRT2(precision: 128)       // 641 bits
+        let narrow = BigFloat.sqrt(BigFloat(3))         // 129 bits, larger
+        #expect(wide != narrow)
+        #expect(wide < narrow)
+        #expect(!(narrow < wide))
+        #expect(BigFloat(1) != BigFloat(2))
+        // a one-bit difference at the bottom of a wide mantissa must not be lost
+        var nudged = BigFloat.SQRT2(precision: 128)
+        nudged.mantissa += 1
+        #expect(nudged != wide, "differing in the last stored bit is a difference")
+        #expect(wide < nudged)
+    }
+}
+
+///
+/// The same defect in `BigRat`, and the same fix.
+///
+/// `init(_:_:)` reduces, so ordinary arithmetic never produced an unreduced value --
+/// which is why `==` comparing `num` and `den` looked sound.  But `init(num:den:)` is
+/// a protocol requirement that stores what it is given, `num` and `den` are settable,
+/// and `BigRat(someBigFloat)` writes `mantissa / 2^-scale` without reducing.
+///
+@Suite struct BigRatEqualityTests {
+
+    /// Reached through a conversion, which is how this turned up: the same √2 as a
+    /// 129-bit fraction and as a 641-bit one.
+    @Test func theSameNumberUnreducedIsEqual() {
+        let a = BigRat(BigFloat.sqrt(BigFloat(2)))
+        let b = BigRat(BigFloat.SQRT2(precision: 128))
+        #expect(a.den.bitWidth != b.den.bitWidth, "two fractions")
+        #expect((a - b).isZero, "one number")
+        #expect(a == b)
+        #expect(!a.isIdentical(to: b), "`isIdentical(to:)` still reports the fractions differ")
+        #expect(a.hashValue == b.hashValue)
+        #expect(a <= b && a >= b)
+        #expect([a < b, a == b, a > b].filter { $0 }.count == 1,
+                "exactly one of <, == and > -- the contract that was broken")
+    }
+
+    /// `init(num:den:)` stores without reducing, by design -- it is the primitive the
+    /// reducing `init(_:_:)` is built on.  Equality has to cope with its output.
+    @Test func theRawInitializerDoesNotReduce() {
+        let half = BigRat(num: BigInt(2), den: BigInt(4))
+        #expect(half.den == 4, "stored as given")
+        #expect(BigRat(2, 4).den == 2, "where init(_:_:) reduces")
+        #expect(half == BigRat(1, 2))
+        #expect(half.hashValue == BigRat(1, 2).hashValue)
+        #expect([half < BigRat(1,2), half == BigRat(1,2), half > BigRat(1,2)].filter { $0 }.count == 1)
+        // and a negative denominator denotes the same number as its negation
+        #expect(BigRat(num: BigInt(-1), den: BigInt(-2)) == BigRat(1, 2))
+        #expect(BigRat(num: BigInt(-1), den: BigInt(2)) == BigRat(-1, 2))
+    }
+
+    /// The IEEE cases, which the fix had to leave alone.
+    @Test func theIEEECasesStillHold() {
+        #expect(BigRat(0) == -BigRat(0))
+        #expect(BigRat(0).hashValue == (-BigRat(0)).hashValue, "±0 are ==, so must hash alike")
+        #expect(BigRat.nan != BigRat.nan)
+        #expect(BigRat.nan.isIdentical(to: BigRat.nan), "no `===` operator on the rationals, only BigFloat has one")
+        #expect(BigRat.infinity == BigRat.infinity)
+        #expect(-BigRat.infinity == -BigRat.infinity)
+        #expect(BigRat.infinity != -BigRat.infinity)
+        #expect(BigRat.infinity != BigRat(1))
+        #expect(!(BigRat.infinity < BigRat.infinity), "and infinity is not below itself")
+        #expect(BigRat.infinity <= BigRat.infinity)
+        #expect(-BigRat.infinity < BigRat.infinity)
+    }
+
+    /// Where a broken hash shows as a wrong count rather than a wrong comparison.
+    @Test func aSetHoldsEachNumberOnce() {
+        let s: Set<BigRat> = [BigRat(BigFloat.sqrt(BigFloat(2))),
+                              BigRat(BigFloat.SQRT2(precision: 128)),
+                              BigRat(num: BigInt(2), den: BigInt(4)), BigRat(1, 2),
+                              BigRat(2, 4), BigRat(0), -BigRat(0)]
+        #expect(s.count == 3, "√2, 1/2 and zero -- got \(s.count)")
+    }
+
+    /// Different numbers stay different, reduced or not.
+    @Test func differentNumbersStayDifferent() {
+        #expect(BigRat(1, 3) != BigRat(1, 2))
+        #expect(BigRat(1, 2) < BigRat(2, 3))
+        #expect(!(BigRat(2, 3) < BigRat(1, 2)))
+        #expect(BigRat(num: BigInt(2), den: BigInt(4)) != BigRat(1, 3))
+        #expect(BigRat(num: BigInt(2), den: BigInt(4)) < BigRat(2, 3))
+        // ordering across unreduced forms, including a negative denominator
+        #expect(BigRat(num: BigInt(-3), den: BigInt(-6)) < BigRat(num: BigInt(4), den: BigInt(6)))
+    }
+
+    /// The fix is on `RationalType`, so the fixed-width rationals get it too.
+    @Test func theFixedWidthRationalsGetItAsWell() {
+        #expect(IntRat(num: 2, den: 4) == IntRat(1, 2))
+        #expect(IntRat(num: 2, den: 4).hashValue == IntRat(1, 2).hashValue)
+        #expect(IntRat(1, 3) != IntRat(1, 2))
+        #expect(IntRat(1, 3) < IntRat(1, 2))
+    }
+}


### PR DESCRIPTION
Two commits, separable if you'd rather split them: a correctness fix in `BigNum`, and the example package that turned it up.

## 1. `==` compared storage, not value

`BigFloat.isEqual(to:)` was `isIdentical(to:)` — `scale` and `mantissa`. `RationalType.isEqual(to:)` was the same on `num` and `den`. Both are sound only if every value is stored canonically, and neither type manages that:

```swift
let a = BigFloat.sqrt(BigFloat(2))          // mantissa 129 bits
let b = BigFloat.SQRT2(precision: 128)      // mantissa 641 bits, low 512 zeroed
(a - b).isZero                  // true  — one number
a.description == b.description  // true  — prints the same
a < b, a == b, a > b            // false, false, false
```

All three false violates `Comparable`, which `FloatingPoint` inherits. **`<` was never at fault** — `BigFloat` compares by subtraction, `RationalType` cross-multiplies, and both were right the whole time. `==` was the only liar.

Where the non-canonical values come from:

| | how |
|---|---|
| `BigFloat` | `truncate(width:)` rounds the mantissa in place, zeroing low bits without moving them into the scale as `init(scale:mantissa:)` would. `pow(4, 0.5)` is 2, stored as 2⁷⁶³ × 2⁻⁷⁶². |
| `BigRat` | `BigRat(someBigFloat)` writes `mantissa / 2^-scale` without reducing; `init(num:den:)` is a protocol requirement that stores what it is given. |

"Normalize the producers instead" was not available: `scale`, `mantissa`, `num` and `den` are all settable `public var`s, so any caller can denormalize a value and representation equality can never be safe.

`BigFloat` now compares what `init(scale:mantissa:)` would have stored, without building it — shift each mantissa down by its trailing zeros, compare the pair. `BigRat` cross-multiplies, which `isLessThan` already pays for every unequal pair, and which is sign-agnostic so `BigRat(num: -1, den: -2) == BigRat(1, 2)` needs no special case. `isLessThan` now derives equality from those same two products instead of calling `isEqual` and paying twice.

`hash(into:)` had to follow, being synthesized from the stored properties — equal values hashed differently, so a `Set` held one number twice. `BigFloat` hashes the shifted pair; `RationalType` reduces by gcd, a cost paid on hashing and not on comparing. Both fold ±0 together, being `==`.

`===`/`isIdentical(to:)` are unchanged — comparing storage is their job, and BigFloat.md already documented them that way.

### Measured, since `<` runs in every series loop

Stashed the change, rebuilt, ran both three times @1024 bits:

| | baseline | fixed |
|---|---:|---:|
| `LN2` | 7.23–7.46 ms | 7.23–7.47 ms |
| `LN10` | 11.83–12.08 ms | 11.79–12.08 ms |
| `ATAN1` | 2.48–2.50 ms | 2.48–2.49 ms |

Identical inside run-to-run variance.

### One existing assertion was recording the defect as a feature

```swift
#expect(BigFloat.pow(BigFloat(4), BigFloat(0.5)) != 2, "which is worth knowing")
```

It **is** 2. Now `== 2`, and the "pow rounds to 128 bits" point it was making uses a case that genuinely rounds — `pow(3, 0.5)` squared misses 3 by 8.7e-39.

Twelve new tests, each pinning `[a < b, a == b, a > b].filter { $0 }.count == 1` alongside hash and `Set` behaviour, covering ±0, ±∞, NaN, negative denominators, the raw initializer, and `IntRat` — the rational fix is on `RationalType`, so the fixed-width rationals get it too. Six mutations tried, all caught.

## 2. `SwiftNumericsExample`

A package of its own, like `Benchmarks`, so the root manifest keeps its no-dependencies property.

The manifest needed three fixes to build: the parent was a `url: ".."` dependency with a deprecated `.branch("main")`, which clones the parent and resolves it to a *committed* revision — so the demo tested whatever was last committed rather than the checkout it sits in. Bare product strings name targets in the same package, hence `product 'BigNum' ... not found`. And `Tests/` had no `.testTarget`.

Making `Complex` work is the point. Every method `RealModule.Real` wants is already there — the compiler says `candidate exactly matches` — but four members have a default in **both** hierarchies (`sqrt`, `exp10`, `reciprocal`, `signGamma`), plus `/` for `BigRat`. Two equally specific candidates leave a requirement *unsatisfied*, not overloaded. A concrete-type member outranks both, so five are written out and the other thirty-odd need nothing.

The trap: those five are requirements of BigNum's protocols too, so a concrete `sqrt` becomes BigNum's witness as well — a body calling `BigFloat.sqrt(x)` compiles and recurses until the stack ends. `BigNumBridge.swift` calls the `precision:`-taking twins, which are extension members rather than requirements. One test calls all five directly, so a stack overflow fails the run where the type checker cannot see it.

### Two interop notes worth knowing

- **`BigNum.Real` cannot be spelled.** `public class BigNum {}` shadows the module name: *"'Real' is not a member type of class 'BigNum.BigNum'"*. Disambiguating BigNum's side needs a typealias made in a file that imports only BigNum.
- **Swift 6 mode cannot read `BigFloat.precision`**, let alone set it — mutable `static var`, and the error hides inside `#expect`'s macro expansion. So the demo is stuck at the default 128 bits. `nonisolated(unsafe)` would fix it for v6 consumers at the cost of needing a 5.10+ compiler; not done here.

Eleven tests, including that `Complex<BigRat>` division is exact — `(1+2i)/(3+4i)` is `(11+2i)/25`, and 25 is not a power of two, so no binary float lands on either component.

## Verification

110 tests in `BigNum` and 11 in the example, both from a clean `.build`. The two `withKnownIssue` blocks that recorded these bugs are gone, because the bugs are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)