### PR TITLE
Add SwiftComplexExample: Complex over BigNum via dankogai/swift-complex

### DIFF
--- a/SwiftComplexExample/.gitignore
+++ b/SwiftComplexExample/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/SwiftComplexExample/Package.swift
+++ b/SwiftComplexExample/Package.swift
@@ -1,0 +1,42 @@
+// swift-tools-version: 6.3
+//
+// The same exercise as SwiftNumericsExample, against dankogai/swift-complex rather
+// than apple/swift-numerics, and a package of its own for the same reason: SwiftPM
+// resolves every declared dependency whether the target using it is being built or
+// not, and swift-bignum's own manifest is meant to fetch nothing.
+//
+//     cd SwiftComplexExample && swift test
+//
+// swift-complex depends on swift-bignum itself, from 6.3.0.  The `path:".."` below
+// declares the same package identity -- `swift-bignum`, taken from the directory
+// name -- and a root path dependency wins, so both this package and swift-complex
+// build against the checkout rather than a published tag.  That is the point of
+// using a path here: the demo tests the working tree.
+//
+import PackageDescription
+
+let package = Package(
+    name: "SwiftComplexExample",
+    products: [
+        .library(
+            name: "SwiftComplexExample",
+            targets: ["SwiftComplexExample"]
+        ),
+    ],
+    dependencies: [
+      .package(url:"https://github.com/dankogai/swift-complex.git", branch:"main"),
+      .package(path:".."),
+    ],
+    targets: [
+        .target(
+            name: "SwiftComplexExample",
+            dependencies: [
+                .product(name: "BigNum", package: "swift-bignum"),
+                .product(name: "Complex", package: "swift-complex"),
+            ]),
+        .testTarget(
+            name: "SwiftComplexExampleTests",
+            dependencies: ["SwiftComplexExample"]),
+    ],
+     swiftLanguageModes: [.v6]
+)

--- a/SwiftComplexExample/Sources/SwiftComplexExample/ComplexConformance.swift
+++ b/SwiftComplexExample/Sources/SwiftComplexExample/ComplexConformance.swift
@@ -1,0 +1,29 @@
+//
+//  ComplexConformance.swift -- BigRat and BigFloat as swift-complex `RMath`s, so
+//  that `Complex<BigRat>` and `Complex<BigFloat>` work.
+//
+//  Two empty extensions, and unlike SwiftNumericsExample they were empty from the
+//  start.  swift-complex's `RMath` declares the elementary functions as
+//  *requirements* and deliberately provides no defaults for the ones swift-bignum
+//  already has, so there is nothing for BigNum's implementations to tie with:
+//  each requirement has exactly one candidate, and it is BigNum's.
+//
+//  It also declares the `precision:debug:` forms as requirements rather than
+//  conveniences, which is what lets generic code inside `Complex` dispatch to
+//  arbitrary precision instead of binding a forwarder that drops the argument.
+//  That is the whole difference between this file and the swift-numerics one.
+//
+//  Requires swift-complex's `main`.  Tag 5.0.0 spells the protocol
+//  `FloatingPointMath`, with only `init(_:Double)` and `asDouble` as requirements
+//  and every function supplied as an extension default routed through `Double`.
+//  Conforming to that compiles, and then `Complex<BigRat>.exp(z)` returns exactly
+//  what `Complex<Double>` returns -- 1.22e-16 from -1 for `exp(iπ)` rather than
+//  1e-39 -- because generic code inside `Complex` can only see the Double-routed
+//  default.  Silent, not an error.  It also makes about two dozen function names
+//  ambiguous at any call site that imports both modules.
+//
+import BigNum
+import Complex
+
+extension BigRat: RMath {}
+extension BigFloat: RMath {}

--- a/SwiftComplexExample/Sources/SwiftComplexExample/SwiftComplexExample.swift
+++ b/SwiftComplexExample/Sources/SwiftComplexExample/SwiftComplexExample.swift
@@ -1,0 +1,60 @@
+//
+//  SwiftComplexExample.swift -- BigNum and dankogai/swift-complex together.
+//
+//  Everything here is asserted in the test suite, so the comments are checked
+//  rather than claimed.
+//
+import BigNum
+import Complex
+
+/// Complex division over an *exact* type.
+///
+/// `(1+2i)/(3+4i)` is `(11+2i)/25` -- 0.44 + 0.08i -- and 25 is not a power of two,
+/// so no binary float lands on either component.  Over `BigRat` the answer is the
+/// number itself, and multiplying back returns exactly what you started with.
+public func exactComplexDivision() -> (quotient: Complex<BigRat>, roundTrips: Bool) {
+    let q = Complex<BigRat>(1, 2) / Complex<BigRat>(3, 4)
+    return (q, q * Complex<BigRat>(3, 4) == Complex<BigRat>(1, 2))
+}
+
+/// `exp(iπ) == -1` at whatever precision you ask for.
+///
+/// This is the part SwiftNumericsExample cannot do.  swift-numerics' `Complex` has
+/// no precision parameter, so it runs at whatever `BigFloat.precision` says -- and
+/// under Swift 6 language mode that static cannot even be read, let alone set.
+/// swift-complex threads `precision:` through every function, so a caller picks the
+/// width at the call site and no global is involved.
+public func eulerIdentity(precision px: Int) -> Complex<BigFloat> {
+    return Complex<BigFloat>.exp(Complex<BigFloat>(0, BigFloat.PI(precision: px)),
+                                 precision: px, debug: false)
+}
+
+/// How far `exp(iπ)` lands from -1, as a `Double`, for each width.  Reporting it as
+/// a `Double` runs out before the arithmetic does: at 1024 bits the miss is 9.2e-309,
+/// already a subnormal.
+public func precisionLadder(_ widths: [Int] = [128, 256, 512]) -> [(bits: Int, error: Double)] {
+    return widths.map { px in
+        let z = eulerIdentity(precision: px)
+        return (px, ((z.real + 1).magnitude + z.imag.magnitude).toDouble())
+    }
+}
+
+/// √i = (1+i)/√2, over `BigFloat`.
+public func squareRootOfI() -> Complex<BigFloat> {
+    return Complex<BigFloat>.sqrt(Complex<BigFloat>(0, 1))
+}
+
+/// Prints the four above.  `swift test` is where the checking is.
+public func demo() {
+    let (q, roundTrips) = exactComplexDivision()
+    print("Complex<BigRat>: (1+2i)/(3+4i) = \(q.real.toString()) + \(q.imag.toString())i")
+    print("                exact 11/25 and 2/25? \(q.real == BigRat(11, 25) && q.imag == BigRat(2, 25))")
+    print("                multiplies back exactly? \(roundTrips)")
+    for (bits, error) in precisionLadder([128, 256, 512, 1024]) {
+        print("Complex<BigFloat>: exp(iπ) at \(bits) bits misses -1 by \(error)")
+    }
+    let d = Complex<Double>.exp(Complex<Double>(0, Double.pi))
+    print("Complex<Double>:   exp(iπ) misses -1 by \((d.real + 1).magnitude + d.imag.magnitude)")
+    let r = squareRootOfI()
+    print("Complex<BigFloat>: √i = \(r.real.toDouble()) + \(r.imag.toDouble())i")
+}

--- a/SwiftComplexExample/Tests/SwiftComplexExampleTests/SwiftComplexExampleTests.swift
+++ b/SwiftComplexExample/Tests/SwiftComplexExampleTests/SwiftComplexExampleTests.swift
@@ -1,0 +1,128 @@
+import Testing
+import BigNum
+import Complex
+@testable import SwiftComplexExample
+
+///
+/// `Complex<BigRat>` and `Complex<BigFloat>` over dankogai/swift-complex.
+///
+/// The conformances are two empty extensions, so the interesting question is not
+/// whether they compile but whether the arithmetic that results is BigNum's.
+/// swift-complex 5.0.0 would compile these too and then compute every
+/// transcendental in `Double`, silently, because its protocol supplies the
+/// functions as extension defaults routed through `asDouble` instead of declaring
+/// them as requirements.  Most of what follows exists to catch that.
+///
+@Suite struct ConformanceTests {
+
+    /// The one that matters.  If the witnesses were swift-complex's Double-routed
+    /// defaults rather than BigNum's own functions, this error would be 1.2e-16 --
+    /// exactly what `Complex<Double>` gives -- instead of about 1e-39.
+    @Test func transcendentalsUseBigNumAndNotDouble() {
+        let z = eulerIdentity(precision: 128)
+        let err = ((z.real + 1).magnitude + z.imag.magnitude).toDouble()
+        #expect(err < 1e-38, "exp(iπ) at 128 bits misses -1 by \(err)")
+        #expect(err > 0, "and it is not exactly -1 either")
+        let d = Complex<Double>.exp(Complex<Double>(0, Double.pi))
+        let derr = ((d.real + 1).magnitude + d.imag.magnitude)
+        #expect(derr > 1e-17 && derr < 1e-15, "Double's own miss, for contrast: \(derr)")
+        #expect(err < derr / 1e20, "BigNum's answer is many orders better, not equal")
+    }
+
+    /// `precision:` is threaded through, so the width is a call-site decision and no
+    /// global is touched -- which is what SwiftNumericsExample could not manage under
+    /// Swift 6 language mode.
+    @Test func precisionIsACallSiteDecision() {
+        let ladder = precisionLadder([128, 256, 512])
+        #expect(ladder.count == 3)
+        // each doubling of the width squares the accuracy, roughly
+        #expect(ladder[0].error < 1e-38 && ladder[0].error > 1e-40, "128 bits: \(ladder[0].error)")
+        #expect(ladder[1].error < 1e-76 && ladder[1].error > 1e-78, "256 bits: \(ladder[1].error)")
+        #expect(ladder[2].error < 1e-154 && ladder[2].error > 1e-156, "512 bits: \(ladder[2].error)")
+        #expect(ladder[0].error > ladder[1].error && ladder[1].error > ladder[2].error)
+        // at 1024 bits the miss is a *subnormal* Double -- 9.2e-309, past the
+        // 2.2e-308 where normal Doubles stop -- so reporting it as one is already
+        // stretching the messenger
+        let far = precisionLadder([1024])[0]
+        #expect(far.error < 1e-300, "1024 bits: \(far.error)")
+        #expect(far.error > 0, "and not quite zero yet")
+    }
+
+    /// Names that were ambiguous against swift-complex 5.0.0 -- whose protocol
+    /// extension defaulted about two dozen functions -- resolve here, because `main`
+    /// declares them as requirements instead.
+    @Test func theFunctionNamesAreNotAmbiguous() {
+        #expect(BigRat.exp(0) == 1)
+        #expect(BigFloat.sqrt(BigFloat(4)) == 2)
+        #expect(BigRat.log(1) == 0)
+        #expect((BigFloat.cos(BigFloat(0)) - 1).isZero)
+        #expect(BigRat.hypot(3, 4) == 5)
+        #expect((BigFloat.atan2(y: 0, x: 1)).isZero)
+        // Double keeps working too: swift-complex routes it through a marker protocol
+        // so that its witnesses do not collide with BigNum's concrete ones
+        #expect(Double.exp(0.0) == 1.0)
+        #expect(Double.sqrt(4.0) == 2.0)
+    }
+}
+
+///
+/// The arithmetic, over both types, on values that are exact in binary so agreement
+/// is agreement rather than luck.
+///
+@Suite struct ComplexTests {
+
+    @Test func arithmeticOverBothTypes() {
+        let a = Complex<BigRat>(1, 2), b = Complex<BigRat>(3, 4)
+        #expect(a + b == Complex<BigRat>(4, 6))
+        #expect(a - b == Complex<BigRat>(-2, -2))
+        #expect(a * b == Complex<BigRat>(-5, 10))
+        let f = Complex<BigFloat>(1, 2), g = Complex<BigFloat>(3, 4)
+        #expect(f + g == Complex<BigFloat>(4, 6))
+        #expect(f - g == Complex<BigFloat>(-2, -2))
+        #expect(f * g == Complex<BigFloat>(-5, 10))
+        // i² == -1, spelled with swift-complex's `.i` on a real
+        #expect(BigRat(1).i * BigRat(1).i == Complex<BigRat>(-1, 0))
+    }
+
+    /// Division over an exact type is exact: (1+2i)/(3+4i) is (11+2i)/25, and
+    /// neither 0.44 nor 0.08 is a binary fraction.
+    @Test func divisionIsExactOverBigRat() {
+        let (q, roundTrips) = exactComplexDivision()
+        #expect(q.real == BigRat(11, 25) && q.imag == BigRat(2, 25),
+                "got \(q.real.toString()) + \(q.imag.toString())i")
+        #expect(roundTrips)
+        // Double has no 11/25 to land on -- 25 is not a power of two
+        let qd = Complex<Double>(1, 2) / Complex<Double>(3, 4)
+        #expect(BigRat(qd.real) != BigRat(11, 25), "Double's 0.44 is not 11/25")
+    }
+
+    @Test func squareRootOfIIsTheExpectedOne() {
+        let r = squareRootOfI()
+        #expect(r.real.toDouble() == 0.7071067811865476)
+        #expect(r.imag.toDouble() == 0.7071067811865476)
+        // and squaring it returns i, to the precision in play
+        let sq = r * r
+        #expect(sq.real.magnitude < BigFloat.getEpsilon(precision: 100))
+        #expect((sq.imag - 1).magnitude < BigFloat.getEpsilon(precision: 100))
+    }
+
+    /// Both types agree with `Double` where a `Double` is exact.
+    @Test func agreesWithDoubleWhereDoubleIsExact() {
+        for (re, im) in [(1.0, 2.0), (-3.0, 0.5), (0.0, -1.0), (2.5, -4.25)] {
+            let w = Complex<Double>(1.5, -2.0)
+            let zd = Complex<Double>(re, im) * w
+            let zr = Complex<BigRat>(BigRat(re), BigRat(im)) * Complex<BigRat>(BigRat(1.5), BigRat(-2.0))
+            let zf = Complex<BigFloat>(BigFloat(re), BigFloat(im))
+                       * Complex<BigFloat>(BigFloat(1.5), BigFloat(-2.0))
+            #expect(zr.real.toDouble() == zd.real && zr.imag.toDouble() == zd.imag, "BigRat at \(re),\(im)")
+            #expect(zf.real.toDouble() == zd.real && zf.imag.toDouble() == zd.imag, "BigFloat at \(re),\(im)")
+        }
+    }
+}
+
+/// The demo entry points, so that what the comments show is what runs.
+@Suite struct DemoTests {
+    @Test func demoAgreesWithItsComments() {
+        demo()
+    }
+}


### PR DESCRIPTION
The same exercise as `SwiftNumericsExample` against a different `Complex`, and a package of its own for the same reason — SwiftPM resolves every declared dependency whether the target using it is being built or not, and swift-bignum's own manifest is meant to fetch nothing.

```bash
cd SwiftComplexExample && swift test
```

## The conformance is two empty extensions

```swift
extension BigRat: RMath {}
extension BigFloat: RMath {}
```

Unlike the swift-numerics one, they were empty at the first attempt. `swift-complex`'s `RMath` declares the elementary functions as **requirements** and deliberately supplies no defaults for the ones swift-bignum already has, so nothing ties: each requirement has exactly one candidate and it is BigNum's. No bridge file, no hand-written witnesses, no recursion hazard.

It also declares the `precision:debug:` forms as requirements rather than conveniences, which is what lets generic code inside `Complex` dispatch to arbitrary precision instead of binding a forwarder that drops the argument.

## And it does something SwiftNumericsExample cannot

`precision:` is threaded through every function, so the width is a call-site decision with no global involved. swift-numerics' `Complex` has no precision parameter, so it runs at whatever `BigFloat.precision` says — and Swift 6 language mode refuses even to *read* that static.

| bits | `|exp(iπ) + 1|` |
|---:|---:|
| 128 | 2.10e-39 |
| 256 | 1.28e-77 |
| 512 | 2.19e-155 |
| 1024 | 9.17e-309 — a subnormal `Double` |
| `Complex<Double>` | 1.22e-16 |

Reporting the error as a `Double` runs out before the arithmetic does. I had assumed 1024 bits would underflow to zero and had to correct both the assertion and a doc comment when it turned out subnormal.

## What a reviewer should know: this pins a branch

**The dependency is on swift-complex's `main`, because `RMath` is unreleased.** A branch pin in a committed manifest drifts under you; if you cut a release containing `RMath`, this should point at that tag instead. Flagging it because it is the one thing here that will rot.

The reason it is not on 5.0.0: that tag spells the protocol `FloatingPointMath`, with only `init(_:Double)` and `asDouble` as requirements and about two dozen functions supplied as extension defaults routed through `asDouble`. Conforming to that compiles, and then

```
Complex<BigRat>.exp(iπ)   im = 1.2246467991473532e-16
Complex<Double>.exp(iπ)   im = 1.2246467991473532e-16   ← bit-for-bit identical
```

Arbitrary precision gone, silently — generic code inside `Complex` can only see the Double-routed default, so there is no error and no warning. It also makes those two dozen names ambiguous at any call site importing both modules: `BigRat.exp(1)` does not compile. Division stays exact either way, being plain arithmetic rather than `FloatingPointMath`.

That measurement is worth acting on independently of this PR — the released tag cannot do arbitrary-precision complex transcendentals with BigNum, and `main` already fixes it.

## Testing

Eight tests, from a clean `.build`:

- `transcendentalsUseBigNumAndNotDouble` — the important one. It asserts the 128-bit error is under 1e-38 *and* at least twenty orders better than `Double`'s, so a regression to the 5.0.0 behaviour fails it. The 1.22e-16 measured against 5.0.0 is what says it would.
- the precision ladder above, including that each doubling of the width roughly squares the accuracy
- that the two dozen contested names resolve — `BigRat.exp`, `BigFloat.sqrt`, `BigRat.hypot`, `BigFloat.atan2`, and `Double.exp`/`Double.sqrt` alongside them
- exact `Complex<BigRat>` division: `(1+2i)/(3+4i)` is `(11+2i)/25`, and 25 is not a power of two, so no binary float lands on either component
- arithmetic over both types, `√i`, and agreement with `Double` where a `Double` is exact

BigNum itself is untouched by this PR, and `SwiftNumericsExample`'s 11 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)